### PR TITLE
MRIQC update

### DIFF
--- a/python/mia_processes/bricks/preprocess/afni/processes.py
+++ b/python/mia_processes/bricks/preprocess/afni/processes.py
@@ -799,7 +799,7 @@ class DropTRs(ProcessMIA):
         self.process.outputtype = self.output_type
         self.process.start_idx = self.start_idx
         if self.stop_idx == -1:
-            self.process.stop_idx = nb_volumes
+            self.process.stop_idx = nb_volumes - 1
         else:
             self.process.stop_idx = self.stop_idx
         self.process.out_file = self.out_file

--- a/python/mia_processes/bricks/preprocess/ants/processes.py
+++ b/python/mia_processes/bricks/preprocess/ants/processes.py
@@ -753,8 +753,8 @@ class Registration(ProcessMIA):
                             desc=metric_desc))
 
         self.add_trait("metric_weight",
-                       List(Int(),
-                            default=[1, 1, 1],
+                       List(Float(),
+                            default=[1.0, 1.0, 1.0],
                             output=False,
                             optional=True,
                             desc=metric_weight_desc))

--- a/python/mia_processes/bricks/preprocess/freesurfer/__init__.py
+++ b/python/mia_processes/bricks/preprocess/freesurfer/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*- #
+
+##########################################################################
+# mia_processes - Copyright (C) IRMaGe/CEA, 2018
+# Distributed under the terms of the CeCILL license, as published by
+# the CEA-CNRS-INRIA. Refer to the LICENSE file or to
+# http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.html
+# for details.
+##########################################################################
+
+from .processes import (Binarize, SynthStrip)

--- a/python/mia_processes/bricks/preprocess/freesurfer/processes.py
+++ b/python/mia_processes/bricks/preprocess/freesurfer/processes.py
@@ -1,0 +1,554 @@
+"""The freesurfer preprocess library of the mia_processes package.
+
+The purpose of this module is to customise the main freesurfer preprocessing bricks
+provided by nipype and to correct some things that do not work directly in
+populse_mia.
+
+:Contains:
+    :Class:
+        - Binarize
+        - SynthStrip
+
+"""
+
+##########################################################################
+# mia_processes - Copyright (C) IRMaGe/CEA, 2018
+# Distributed under the terms of the CeCILL license, as published by
+# the CEA-CNRS-INRIA. Refer to the LICENSE file or to
+# http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.html
+# for details.
+##########################################################################
+
+# populse_mia import
+from populse_mia.user_interface.pipeline_manager.process_mia import ProcessMIA
+
+# Other import
+import os
+from traits.api import Bool, Either, Enum, File, Float, Int, List, Undefined, String 
+import capsul
+from capsul.in_context import freesurfer
+
+EXT = {'NIFTI_GZ': 'nii.gz',
+       'NIFTI': 'nii',
+       'MGZ': 'mgz'}
+
+
+class Binarize(ProcessMIA):
+    """
+    * Use FreeSurfer mri_binarize to binarize a volume
+    (or volume-encoded surface file).
+    Can also be used to merge with other binarizations.
+    Binarization can be done based on threshold or on matched values. *
+
+    Please, see the complete documentation for the `Binarize' brick in the populse.mia_processes website
+    <https://populse.github.io/mia_processes/documentation/bricks/preprocess/freesurfer/Binarize.html>`
+
+    """
+
+    def __init__(self):
+        '''Dedicated to the attributes initialisation/instantiation.
+
+        The input and output plugs are defined here. The special
+        'self.requirement' attribute (optional) is used to define the
+        third-party products necessary for the running of the brick.
+        '''
+        # Initialisation of the objects needed for the launch of the brick
+        super(Binarize, self).__init__()
+
+        # Third party softwares required for the execution of the brick
+        self.requirement = ['freesurfer', 'nipype']
+
+        # Inputs description
+        in_file_desc = ('Input file (a pathlike object or string '
+                        'representing a file).')
+        min_desc = 'Minimum voxel threshold(float).'
+        max_desc = 'Maximum voxel threshold(float).'
+        rmin_desc = 'Compute min based on rmin*globalmean.'
+        rmax_desc = 'Compute max based on rmax*globalmean.'
+        match_desc = 'Match instead of threshold'
+        wm_desc = 'set match vals to 2 and 41 (aseg for cerebral WM)'
+        ventricles_desc = ('set match vals those for aseg '
+                           'ventricles+choroid (not 4th)')
+        wm_ven_csf_desc = ('WM and ventricular CSF,'
+                           'including choroid (not 4th)')
+        count_file_desc = ('save number of hits in ascii file'
+                           '(hits, ntotvox, pct)')
+        bin_val_desc = 'set vox outside range to val (default is 0)'
+        bin_val_not_desc = 'set vox outside range to val (default is 0)'
+        invert_desc = 'set binval=0, binvalnot=1'
+        frame_no_desc = 'use 0-based frame of input (default is 0)'
+        merge_file_desc = 'merge with mergevol'
+        mask_file_desc = 'must be within mask'
+        mask_thresh_desc = 'set thresh for mask'
+        abs_desc = 'take abs of invol first (ie, make unsigned)'
+        bin_col_num_desc = 'set binarized voxel value to its column number'
+        zero_edges_desc = 'zero the edge voxels'
+        zero_slice_edge_desc = 'zero the edge slice voxels'
+        dilate_desc = 'niters: dilate binarization in 3D'
+        erode_desc = ('nerode: erode binarization in 3D '
+                      '(after any dilation)')
+        erode2d_desc = ('nerode2d: erode binarization in 2D '
+                        '(after any 3D erosion)')
+
+        output_type_desc = ('Typecodes of the output image formats (one '
+                            'of NIFTI, MGZ, NIFTI_GZ).')
+        out_suffix_desc = 'Suffix of the output image (a string).'
+
+        # Outputs description
+        out_file_desc = ('The binanized file (a pathlike object or a '
+                         'string representing a file).')
+
+        # Inputs traits
+        self.add_trait('in_file',
+                       File(output=False,
+                            optional=False,
+                            desc=in_file_desc))
+
+        self.add_trait('min',
+                       Either(Undefined,
+                              Float(),
+                              default=Undefined,
+                              output=False,
+                              optional=True,
+                              desc=min_desc))
+
+        self.add_trait('max',
+                       Either(Undefined,
+                              Float(),
+                              default=Undefined,
+                              output=False,
+                              optional=True,
+                              desc=max_desc))
+        self.add_trait('rmin',
+                       Either(Undefined,
+                              Float(),
+                              default=Undefined,
+                              output=False,
+                              optional=True,
+                              desc=rmin_desc))
+
+        self.add_trait('rmax',
+                       Either(Undefined,
+                              Float(),
+                              default=Undefined,
+                              output=False,
+                              optional=True,
+                              desc=rmax_desc))
+
+        self.add_trait('match',
+                       Either(Undefined,
+                              List(Int()),
+                              default=Undefined,
+                              output=False,
+                              optional=True,
+                              desc=match_desc))
+
+        self.add_trait('wm',
+                       Bool(default=False,
+                            output=False,
+                            optional=True,
+                            desc=wm_desc))
+
+        self.add_trait('ventricles',
+                       Bool(default=False,
+                            output=False,
+                            optional=True,
+                            desc=ventricles_desc))
+
+        self.add_trait('wm_ven_csf',
+                       Bool(default=False,
+                            output=False,
+                            optional=True,
+                            desc=wm_ven_csf_desc))
+
+        self.add_trait('count_file',
+                       Either(Undefined,
+                              File(),
+                              default=Undefined,
+                              output=False,
+                              optional=True,
+                              desc=count_file_desc))
+
+        self.add_trait('output_type',
+                       Enum('NIFTI',
+                            'NIFTI_GZ',
+                            'MGZ',
+                            output=False,
+                            optional=True,
+                            desc=output_type_desc))
+
+        self.add_trait('out_suffix',
+                       String('_thresh',
+                              output=False,
+                              optional=True,
+                              desc=out_suffix_desc))
+
+        self.add_trait('bin_val',
+                       Either(Undefined,
+                              Int(),
+                              default=Undefined,
+                              output=False,
+                              optional=True,
+                              desc=bin_val_desc))
+
+        self.add_trait('bin_val_not',
+                       Either(Undefined,
+                              Int(),
+                              default=Undefined,
+                              output=False,
+                              optional=True,
+                              desc=bin_val_not_desc))
+
+        self.add_trait('invert',
+                       Bool(default=False,
+                            output=False,
+                            optional=True,
+                            desc=invert_desc))
+
+        self.add_trait('frame_no',
+                       Either(Undefined,
+                              Int(),
+                              default=Undefined,
+                              output=False,
+                              optional=True,
+                              desc=frame_no_desc))
+
+        self.add_trait('merge_file',
+                       Either(Undefined,
+                              File(),
+                              default=Undefined,
+                              output=False,
+                              optional=True,
+                              desc=merge_file_desc))
+
+        self.add_trait('mask_file',
+                       Either(Undefined,
+                              File(),
+                              default=Undefined,
+                              output=False,
+                              optional=True,
+                              desc=mask_file_desc))
+
+        self.add_trait('mask_thresh',
+                       Either(Undefined,
+                              Float(),
+                              default=Undefined,
+                              output=False,
+                              optional=True,
+                              desc=mask_thresh_desc))
+
+        self.add_trait('abs',
+                       Bool(default=False,
+                            output=False,
+                            optional=True,
+                            desc=abs_desc))
+
+        self.add_trait('bin_col_num',
+                       Bool(default=False,
+                            output=False,
+                            optional=True,
+                            desc=bin_col_num_desc))
+
+        self.add_trait('zero_edges',
+                       Bool(default=False,
+                            output=False,
+                            optional=True,
+                            desc=zero_edges_desc))
+
+        self.add_trait('zero_slice_edge',
+                       Bool(default=False,
+                            output=False,
+                            optional=True,
+                            desc=zero_slice_edge_desc))
+
+        self.add_trait('dilate',
+                       Either(Undefined,
+                              Int(),
+                              default=Undefined,
+                              output=False,
+                              optional=True,
+                              desc=dilate_desc))
+
+        self.add_trait('erode',
+                       Either(Undefined,
+                              Int(),
+                              default=Undefined,
+                              output=False,
+                              optional=True,
+                              desc=erode_desc))
+
+        self.add_trait('erode2d',
+                       Either(Undefined,
+                              Int(),
+                              default=Undefined,
+                              output=False,
+                              optional=True,
+                              desc=erode2d_desc))
+        # Outputs traits
+        self.add_trait('out_file',
+                       File(output=True,
+                            desc=out_file_desc))
+
+        self.init_default_traits()
+        self.init_process('nipype.interfaces.freesurfer.Binarize')
+
+    def list_outputs(self, is_plugged=None):
+        """Dedicated to the initialisation step of the brick.
+
+        The main objective of this method is to produce the outputs of the
+        bricks (self.outputs) and the associated tags (self.inheritance_dic),
+        if defined here. In order not to include an output in the database,
+        this output must be a value of the optional key 'notInDb' of the
+        self.outputs dictionary. To work properly this method must return
+        self.make_initResult() object.
+
+        :param is_plugged: the state, linked or not, of the plugs.
+        :returns: a dictionary with requirement, outputs and inheritance_dict.
+        """
+        # Using the inheritance to ProcessMIA class, list_outputs method
+        super(Binarize, self).list_outputs()
+
+        # Outputs definition and tags inheritance (optional)
+        if (self.min != Undefined or
+                self.max != Undefined) and self.match != Undefined:
+            print('\nInitialisation failed. 'match' parameter can not be used '
+                  'with 'min' and/or 'max' parameters'
+                  ' Please, define only 'min'/'max' paremeters or 'match''
+                  'parameters (set the other as Undefined) ...!')
+            return
+        if (self.min != Undefined or
+                self.max != Undefined) and self.wm_ven_csf:
+            print('\nInitialisation failed. 'wm_ven_csf' parameter can not'
+                  'be used  with 'min' and/or 'max' parameters'
+                  ' Please, define only 'min'/'max' paremeters or 'wm_ven_csf''
+                  'parameters (set the other as Undefined) ...!')
+            return
+        if self.in_file:
+            if self.output_directory:
+                output_type = self.output_type
+
+                try:
+                    ifile = os.path.split(self.in_file)[-1]
+                    file_name, in_ext = ifile.rsplit('.', 1)
+                    if in_ext == 'gz':
+                        (file_name_2, in_ext_2) = file_name.rsplit('.', 1)
+                        if in_ext_2 == 'nii':
+                            in_ext = 'nii.gz'
+                except ValueError:
+                    print('\nThe input image format is not recognized ...!')
+                    return
+
+                self.outputs['out_file'] = os.path.join(
+                    self.output_directory,
+                    os.path.split(self.in_file)[1].replace(
+                        '.' + in_ext,
+                        self.out_suffix + '.' + EXT[output_type]))
+
+                self.inheritance_dict[self.outputs[
+                    'out_file']] = self.in_file
+            else:
+                print('No output_directory was found...!\n')
+                return
+
+        # Return the requirement, outputs and inheritance_dict
+        return self.make_initResult()
+
+    def run_process_mia(self):
+        """Dedicated to the process launch step of the brick."""
+        super(Binarize, self).run_process_mia()
+
+        # madatory inputs / outputs
+        self.process.in_file = self.in_file
+        self.process.binary_file = self.out_file
+        self.process.out_type = EXT[self.output_type]
+
+        # optionnal inputs
+        self.process.min = self.min
+        self.process.max = self.max
+        self.process.rmin = self.rmin
+        self.process.rmax = self.rmax
+        self.process.match = self.match
+        self.process.count_file = self.count_file
+        self.process.bin_val = self.bin_val
+        self.process.bin_val_not = self.bin_val_not
+        self.process.frame_no = self.frame_no
+        self.process.merge_file = self.merge_file
+        self.process.mask_file = self.mask_file
+        self.process.mask_thresh = self.mask_thresh
+        self.process.dilate = self.dilate
+        self.process.erode = self.erode
+        self.process.erode2d = self.erode2d
+        self.process.wm = self.wm
+        self.process.ventricles = self.ventricles
+        if self.wm_ven_csf:
+            # only add wm_ven_csf when True because Mutually
+            # exclusive with min/max
+            self.process.wm_ven_csf = self.wm_ven_csf
+        self.process.invert = self.invert
+        self.process.abs = self.abs
+        self.process.bin_col_num = self.bin_col_num
+        self.process.zero_edges = self.zero_edges
+        self.process.zero_slice_edge = self.zero_slice_edge
+
+        return self.process.run(configuration_dict={})
+
+
+class SynthStrip(ProcessMIA):
+    """
+    * Skul stripping using SynthStrip *
+
+    SynthStrip is a skull-stripping tool that extracts brain signal
+    from a landscape of image types, ranging across imaging modality,
+    contrast, resolution, and subject population. It leverages a deep
+    learning strategy  that synthesizes arbitrary training images
+    from segmentation maps to optimize a robust model agnostic
+    to acquisition specifics.
+
+    SynthStrip: Skull-Stripping for Any Brain Image
+    Andrew Hoopes, Jocelyn S. Mora, Adrian V. Dalca, Bruce Fischl*,
+    Malte Hoffmann* (*equal contribution)
+    NeuroImage 260, 2022, 119474
+    https://doi.org/10.1016/j.neuroimage.2022.119474
+
+    Please, see the complete documention for the `Segment' brick in the populse.mia_processes web site
+    <https://populse.github.io/mia_processes/documentation/bricks/preprocess/freesurfer/SynthStrip.html>`_
+
+    """
+
+    def __init__(self):
+        """Dedicated to the attributes initialisation/instantiation.
+
+        The input and output plugs are defined here. The special
+        'self.requirement' attribute (optional) is used to define the
+        third-party products necessary for the running of the brick.
+        """
+        # Initialisation of the objects needed for the launch of the brick
+        super(SynthStrip, self).__init__()
+
+        # Third party softwares required for the execution of the brick
+        self.requirement = ['freesurfer', 'nipype']
+
+        # Inputs description
+        in_file_desc = 'Input image to be brain extracted'
+        border_mm_desc = ('Mask border threshold in mm')
+        output_type_desc = ('Typecodes of the output image formats (one '
+                            'of NIFTI, MGZ, NIFTI_GZ).')
+        no_csf_desc = 'Exclude CSF from brain border'
+
+        # Outputs description
+        out_file_desc = 'Brain-extracted path'
+        out_mask_desc = 'Brainmask path'
+
+        # Inputs traits
+        self.add_trait('in_file',
+                       File(output=False,
+                            optional=False,
+                            desc=in_file_desc))
+
+        self.add_trait('border_mm',
+                       Int(1,
+                           output=False,
+                           optional=True,
+                           desc=border_mm_desc))
+
+        self.add_trait('output_type',
+                       Enum('NIFTI',
+                            'NIFTI_GZ',
+                            'MGZ',
+                            output=False,
+                            optional=True,
+                            desc=output_type_desc))
+
+        self.add_trait('no_csf',
+                       Bool(False,
+                            output=False,
+                            optional=True,
+                            desc=no_csf_desc))
+
+        # Outputs traits
+        self.add_trait('out_file',
+                       File(output=True,
+                            optional=True,
+                            desc=out_file_desc))
+
+        self.add_trait('out_mask',
+                       File(output=True,
+                            desc=out_mask_desc))
+
+        self.init_default_traits()
+
+    def list_outputs(self, is_plugged=None):
+        """Dedicated to the initialisation step of the brick.
+
+        The main objective of this method is to produce the outputs of the
+        bricks (self.outputs) and the associated tags (self.inheritance_dic),
+        if defined here. In order not to include an output in the database,
+        this output must be a value of the optional key 'notInDb' of the
+        self.outputs dictionary. To work properly this method must return
+        self.make_initResult() object.
+
+        :param is_plugged: the state, linked or not, of the plugs.
+        :returns: a dictionary with requirement, outputs and inheritance_dict.
+        """
+        # Using the inheritance to ProcessMIA class, list_outputs method
+        super(SynthStrip, self).list_outputs()
+
+        # Outputs definition and tags inheritance (optional)
+        if self.in_file:
+            if self.output_directory:
+                output_type = self.output_type
+
+                try:
+                    ifile = os.path.split(self.in_file)[-1]
+                    file_name, in_ext = ifile.rsplit('.', 1)
+                    if in_ext == 'gz':
+                        (file_name_2, in_ext_2) = file_name.rsplit('.', 1)
+                        if in_ext_2 == 'nii':
+                            in_ext = 'nii.gz'
+                except ValueError:
+                    print('\nThe input image format is not recognized ...!')
+                    return
+
+                self.outputs['out_file'] = os.path.join(
+                    self.output_directory,
+                    os.path.split(self.in_file)[1].replace(
+                        '.' + in_ext,
+                        '_desc-brain.' + EXT[output_type]))
+
+                self.outputs['out_mask'] = os.path.join(
+                    self.output_directory,
+                    os.path.split(self.in_file)[1].replace(
+                        '.' + in_ext,
+                        '_desc-brain_mask.' + EXT[output_type]))
+
+            else:
+                print('No output_directory was found...!\n')
+                return
+
+        if self.outputs:
+            self.inheritance_dict[self.outputs[
+                'out_file']] = self.in_file
+            self.inheritance_dict[self.outputs[
+                'out_mask']] = self.in_file
+
+        # Return the requirement, outputs and inheritance_dict
+        return self.make_initResult()
+
+    def run_process_mia(self):
+        """Dedicated to the process launch step of the brick."""
+        super(SynthStrip, self).run_process_mia()
+
+        # default input
+        fconf = capsul.engine.configurations.get(
+            'capsul.engine.module.freesurfer')
+        model_path = os.path.join(os.path.dirname(fconf['setup']), 'models',
+                                  'synthstrip.1.pt')
+
+        cmd = ['mri_synthstrip', '-i', self.in_file, '-o',
+               self.out_file, '-m', self.out_mask, '-b', str(self.border_mm),
+               '--model', model_path]
+
+        if self.no_csf:
+            cmd += ['--no-csf']
+
+        return freesurfer.freesurfer_call(cmd)

--- a/python/mia_processes/bricks/preprocess/freesurfer/processes.py
+++ b/python/mia_processes/bricks/preprocess/freesurfer/processes.py
@@ -311,16 +311,16 @@ class Binarize(ProcessMIA):
         # Outputs definition and tags inheritance (optional)
         if (self.min != Undefined or
                 self.max != Undefined) and self.match != Undefined:
-            print('\nInitialisation failed. 'match' parameter can not be used '
-                  'with 'min' and/or 'max' parameters'
-                  ' Please, define only 'min'/'max' paremeters or 'match''
+            print('\nInitialisation failed. "match" parameter can not be used '
+                  'with "min" and/or "max" parameters'
+                  ' Please, define only "min"/"max" paremeters or "match"'
                   'parameters (set the other as Undefined) ...!')
             return
         if (self.min != Undefined or
                 self.max != Undefined) and self.wm_ven_csf:
-            print('\nInitialisation failed. 'wm_ven_csf' parameter can not'
-                  'be used  with 'min' and/or 'max' parameters'
-                  ' Please, define only 'min'/'max' paremeters or 'wm_ven_csf''
+            print('\nInitialisation failed. "wm_ven_csf" parameter can not'
+                  'be used  with "min" and/or "max" parameters'
+                  ' Please, define only "min"/"max" paremeters or "wm_ven_csf"'
                   'parameters (set the other as Undefined) ...!')
             return
         if self.in_file:

--- a/python/mia_processes/bricks/preprocess/fsl/__init__.py
+++ b/python/mia_processes/bricks/preprocess/fsl/__init__.py
@@ -8,4 +8,4 @@
 # for details.
 ##########################################################################
 
-from .processes import (Segment, Smooth)
+from .processes import (Segment, Smooth, SurfacesExtraction)

--- a/python/mia_processes/bricks/preprocess/fsl/processes.py
+++ b/python/mia_processes/bricks/preprocess/fsl/processes.py
@@ -479,13 +479,27 @@ class SurfacesExtraction(ProcessMIA):
             self.process.surfaces = True
 
             if self.output_directory:
-                self.outputs['outskin_mask_file'] = os.path.join(self.output_directory,os.path.split(self.process._outskin_mask_file)[1])
-                self.outputs['outskin_mesh_file'] = os.path.join(self.output_directory,os.path.split(self.process._outskin_mesh_file)[1])
-                self.outputs['outskull_mask_file'] = os.path.join(self.output_directory,os.path.split(self.process._outskull_mask_file)[1])
-                self.outputs['outskull_mesh_file'] = os.path.join(self.output_directory,os.path.split(self.process._outskull_mesh_file)[1])
-                self.outputs['inskull_mask_file'] = os.path.join(self.output_directory,os.path.split(self.process._inskull_mask_file)[1])
-                self.outputs['inskull_mesh_file'] = os.path.join(self.output_directory,os.path.split(self.process._inskull_mesh_file)[1])
-                self.outputs['skull_mask_file'] = os.path.join(self.output_directory,os.path.split(self.process._skull_mask_file)[1])
+                self.outputs['outskin_mask_file'] = os.path.join(
+                    self.output_directory, os.path.split(
+                        self.process._outskin_mask_file)[1])
+                self.outputs['outskin_mesh_file'] = os.path.join(
+                    self.output_directory, os.path.split(
+                        self.process._outskin_mesh_file)[1])
+                self.outputs['outskull_mask_file'] = os.path.join(
+                    self.output_directory, os.path.split(
+                        self.process._outskull_mask_file)[1])
+                self.outputs['outskull_mesh_file'] = os.path.join(
+                    self.output_directory, os.path.split(
+                        self.process._outskull_mesh_file)[1])
+                self.outputs['inskull_mask_file'] = os.path.join(
+                    self.output_directory, os.path.split(
+                        self.process._inskull_mask_file)[1])
+                self.outputs['inskull_mesh_file'] = os.path.join(
+                    self.output_directory, os.path.split(
+                        self.process._inskull_mesh_file)[1])
+                self.outputs['skull_mask_file'] = os.path.join(
+                    self.output_directory, os.path.split(
+                        self.process._skull_mask_file)[1])
         if self.outputs:
             self.inheritance_dict[self.outputs[
                 'outskin_mask_file']] = self.in_file

--- a/python/mia_processes/bricks/preprocess/fsl/processes.py
+++ b/python/mia_processes/bricks/preprocess/fsl/processes.py
@@ -397,6 +397,9 @@ class SurfacesExtraction(ProcessMIA):
         in_file_desc = ('File to delete non-brain tissue (a pathlike object'
                         'string representing a file)')
 
+        output_type_desc = ('Typecodes of the output NIfTI image formats (one '
+                            'of NIFTI, NIFTI_PAIR, NIFTI_GZ, NIFTI_PAIR_GZ).')
+
         # Outputs description
         outskin_mask_file_desc = 'outskin mask file'
         outskin_mesh_file_desc = 'outskin mesh file'
@@ -411,6 +414,15 @@ class SurfacesExtraction(ProcessMIA):
                        File(output=False,
                             optional=False,
                             desc=in_file_desc))
+
+        self.add_trait("output_type",
+                       Enum('NIFTI',
+                            'NIFTI_PAIR',
+                            'NIFTI_GZ',
+                            'NIFTI_PAIR_GZ',
+                            output=False,
+                            optional=True,
+                            desc=output_type_desc))
 
         # Outputs traits
         self.add_trait("outskin_mask_file",
@@ -475,6 +487,7 @@ class SurfacesExtraction(ProcessMIA):
 
         # Outputs definition and tags inheritance (optional)
         if self.in_file:
+            self.process.output_type = self.output_type
             self.process.in_file = self.in_file
             self.process.surfaces = True
 
@@ -522,6 +535,7 @@ class SurfacesExtraction(ProcessMIA):
     def run_process_mia(self):
         """Dedicated to the process launch step of the brick."""
         super(SurfacesExtraction, self).run_process_mia()
+        self.process.output_type = self.output_type
         self.process.in_file = self.in_file
 
         # default inputs

--- a/python/mia_processes/bricks/preprocess/fsl/processes.py
+++ b/python/mia_processes/bricks/preprocess/fsl/processes.py
@@ -8,8 +8,9 @@ populse_mia.
 
 :Contains:
     :Class:
-        - Smooth
         - Segment
+        - Smooth
+        - SurfacesExtraction
 
 """
 
@@ -258,7 +259,7 @@ class Smooth(ProcessMIA):
 
         # To suppress the "FSLOUTPUTTYPE environment
         # variable is not set" nipype warning:
-        if not 'FSLOUTPUTTYPE' in os.environ:
+        if 'FSLOUTPUTTYPE' not in os.environ:
             os.environ['FSLOUTPUTTYPE'] = self.output_type
 
         self.init_process('nipype.interfaces.fsl.Smooth')
@@ -360,4 +361,157 @@ class Smooth(ProcessMIA):
 
         self.process.output_type = self.output_type
         self.process.smoothed_file = self.outf
+        return self.process.run(configuration_dict={})
+
+
+class SurfacesExtraction(ProcessMIA):
+    """
+    * Surfaces (inskull, outskull, outskin) extraction using
+    fsl.BET with option -A (bet2 and betsurf) and -n
+    (no default brain image output)*
+
+    Runs both bet2 and betsurf programs in order to get skull and scalp
+    surfaces created by betsurf.
+    This involves registering to standard space in order to allow betsurf
+    to find the standard space masks it needs.
+
+    Please, see the complete documention for the `SurfacesExtraction' brick in the populse.mia_processes web site
+    <https://populse.github.io/mia_processes/documentation/bricks/preprocess/fsl/SurfacesExtraction.html>`_
+
+    """
+
+    def __init__(self):
+        """Dedicated to the attributes initialisation/instantiation.
+
+        The input and output plugs are defined here. The special
+        'self.requirement' attribute (optional) is used to define the
+        third-party products necessary for the running of the brick.
+        """
+        # Initialisation of the objects needed for the launch of the brick
+        super(SurfacesExtraction, self).__init__()
+
+        # Third party softwares required for the execution of the brick
+        self.requirement = ['fsl', 'nipype']
+
+        # Inputs description
+        in_file_desc = ('File to delete non-brain tissue (a pathlike object'
+                        'string representing a file)')
+
+        # Outputs description
+        outskin_mask_file_desc = 'outskin mask file'
+        outskin_mesh_file_desc = 'outskin mesh file'
+        outskull_mask_file_desc = 'outskull mask file'
+        outskull_mesh_file_desc = 'outskull mesh file'
+        inskull_mask_file_desc = 'inskull mask file'
+        inskull_mesh_file_desc = 'inskull mesh file'
+        skull_mask_file_desc = 'skull mask file'
+
+        # Inputs traits
+        self.add_trait("in_file",
+                       File(output=False,
+                            optional=False,
+                            desc=in_file_desc))
+
+        # Outputs traits
+        self.add_trait("outskin_mask_file",
+                       File(output=True,
+                            optional=True,
+                            desc=outskin_mask_file_desc))
+
+        self.add_trait("outskin_mesh_file",
+                       File(output=True,
+                            optional=True,
+                            desc=outskin_mesh_file_desc))
+
+        self.add_trait("outskull_mask_file",
+                       File(output=True,
+                            optional=True,
+                            desc=outskull_mask_file_desc))
+
+        self.add_trait("outskull_mesh_file",
+                       File(output=True,
+                            optional=True,
+                            desc=outskull_mesh_file_desc))
+
+        self.add_trait("inskull_mask_file",
+                       File(output=True,
+                            optional=True,
+                            desc=inskull_mask_file_desc))
+
+        self.add_trait("inskull_mesh_file",
+                       File(output=True,
+                            optional=True,
+                            desc=inskull_mesh_file_desc))
+
+        self.add_trait("skull_mask_file",
+                       File(output=True,
+                            optional=True,
+                            desc=skull_mask_file_desc))
+
+        self.init_default_traits()
+
+        # To suppress the "FSLOUTPUTTYPE environment
+        # variable is not set" nipype warning:
+        if 'FSLOUTPUTTYPE' not in os.environ:
+            os.environ['FSLOUTPUTTYPE'] = self.output_type
+
+        self.init_process('nipype.interfaces.fsl.BET')
+
+    def list_outputs(self, is_plugged=None):
+        """Dedicated to the initialisation step of the brick.
+
+        The main objective of this method is to produce the outputs of the
+        bricks (self.outputs) and the associated tags (self.inheritance_dic),
+        if defined here. In order not to include an output in the database,
+        this output must be a value of the optional key 'notInDb' of the
+        self.outputs dictionary. To work properly this method must return
+        self.make_initResult() object.
+
+        :param is_plugged: the state, linked or not, of the plugs.
+        :returns: a dictionary with requirement, outputs and inheritance_dict.
+        """
+        # Using the inheritance to ProcessMIA class, list_outputs method
+        super(SurfacesExtraction, self).list_outputs()
+
+        # Outputs definition and tags inheritance (optional)
+        if self.in_file:
+            self.process.in_file = self.in_file
+            self.process.surfaces = True
+
+            if self.output_directory:
+                self.outputs['outskin_mask_file'] = os.path.join(self.output_directory,os.path.split(self.process._outskin_mask_file)[1])
+                self.outputs['outskin_mesh_file'] = os.path.join(self.output_directory,os.path.split(self.process._outskin_mesh_file)[1])
+                self.outputs['outskull_mask_file'] = os.path.join(self.output_directory,os.path.split(self.process._outskull_mask_file)[1])
+                self.outputs['outskull_mesh_file'] = os.path.join(self.output_directory,os.path.split(self.process._outskull_mesh_file)[1])
+                self.outputs['inskull_mask_file'] = os.path.join(self.output_directory,os.path.split(self.process._inskull_mask_file)[1])
+                self.outputs['inskull_mesh_file'] = os.path.join(self.output_directory,os.path.split(self.process._inskull_mesh_file)[1])
+                self.outputs['skull_mask_file'] = os.path.join(self.output_directory,os.path.split(self.process._skull_mask_file)[1])
+        if self.outputs:
+            self.inheritance_dict[self.outputs[
+                'outskin_mask_file']] = self.in_file
+            self.inheritance_dict[self.outputs[
+                'outskin_mesh_file']] = self.in_file
+            self.inheritance_dict[self.outputs[
+                'outskull_mask_file']] = self.in_file
+            self.inheritance_dict[self.outputs[
+                'outskull_mesh_file']] = self.in_file
+            self.inheritance_dict[self.outputs[
+                'inskull_mask_file']] = self.in_file
+            self.inheritance_dict[self.outputs[
+                'inskull_mesh_file']] = self.in_file
+            self.inheritance_dict[self.outputs[
+                'skull_mask_file']] = self.in_file
+
+        # Return the requirement, outputs and inheritance_dict
+        return self.make_initResult()
+
+    def run_process_mia(self):
+        """Dedicated to the process launch step of the brick."""
+        super(SurfacesExtraction, self).run_process_mia()
+        self.process.in_file = self.in_file
+
+        # default inputs
+        self.process.surfaces = True
+        self.process.no_output = True
+
         return self.process.run(configuration_dict={})

--- a/python/mia_processes/bricks/preprocess/others/__init__.py
+++ b/python/mia_processes/bricks/preprocess/others/__init__.py
@@ -8,7 +8,8 @@
 # for details.
 ##########################################################################
 
-from .processing import (ArtifactMask, Binarize, ConformImage, Conv_ROI,
-                         Enhance, GradientThreshold, Harmonize, Mask,
-                         NonSteadyStateDetector, Resample_1, Resample_2,
+from .processing import (ApplyBiasCorrection, ArtifactMask, Binarize,
+                         ConformImage, Conv_ROI, Enhance, GradientThreshold,
+                         Harmonize, IntensityClip,
+                         Mask, NonSteadyStateDetector, Resample_1, Resample_2,
                          RotationMask, Sanitize, Template, Threshold, TSNR)

--- a/python/mia_processes/bricks/preprocess/others/processing.py
+++ b/python/mia_processes/bricks/preprocess/others/processing.py
@@ -3045,7 +3045,7 @@ class Sanitize(ProcessMIA):
 
             # Both match, qform valid (implicit with match), codes okay -> do nothing, empty report
             if matching_affines and qform_code > 0 and sform_code > 0:
-                self.out_file = self.in_file
+                save_file = True
 
             # Row 2:
             elif valid_qform and qform_code > 0:

--- a/python/mia_processes/bricks/preprocess/others/processing.py
+++ b/python/mia_processes/bricks/preprocess/others/processing.py
@@ -5,6 +5,7 @@ pre-processing steps, which are not found in nipype.
 
 :Contains:
     :Class:
+        - ApplyBiasCorrection
         - ArtifactMask
         - Binarize
         - ConformImage
@@ -12,6 +13,7 @@ pre-processing steps, which are not found in nipype.
         - Enhance
         - GradientThreshold
         - Harmonize
+        - IntensityClip
         - Mask
         - NonSteadyStateDetector
         - Resample_1
@@ -60,6 +62,7 @@ from soma.qt_gui.qt_backend.Qt import QMessageBox
 from distutils.dir_util import copy_tree
 from scipy import ndimage as sim
 from skimage.transform import resize
+from skimage.morphology import ball
 import numpy as np
 import os
 import shutil
@@ -68,6 +71,111 @@ import tempfile
 # import templateflow to get anatomical templates
 from templateflow.api import get as get_template
 from statsmodels.robust.scale import mad
+
+
+class ApplyBiasCorrection(ProcessMIA):
+    """
+    *Mask the input given a mask*
+
+    Please, see the complete documentation for the `Threshold brick in the populse.mia_processes website
+    https://populse.github.io/mia_processes/documentation/bricks/preprocess/other/ApplyMask.html
+
+    """
+
+    def __init__(self):
+        """Dedicated to the attributes initialisation / instantiation.
+
+        The input and output plugs are defined here. The special
+        'self.requirement' attribute (optional) is used to define the
+        third-party products necessary for the running of the brick.
+        """
+        # Initialisation of the objects needed for the launch of the brick
+        super(ApplyBiasCorrection, self).__init__()
+
+        # Third party softwares required for the execution of the brick
+        self.requirement = []
+
+        # Inputs description
+        in_file_desc = 'A file'
+        bias_image_desc = 'A mask'
+
+        # Outputs description
+        out_file_desc = 'Out file'
+
+        # Inputs traits
+        self.add_trait("in_file",
+                       File(output=False,
+                            optional=False,
+                            desc=in_file_desc))
+
+        self.add_trait("bias_image",
+                       File(output=False,
+                            optional=False,
+                            desc=bias_image_desc))
+
+        # Outputs traits
+        self.add_trait("out_file",
+                       File(output=True,
+                            desc=out_file_desc))
+
+        self.init_default_traits()
+
+    def list_outputs(self, is_plugged=None):
+        """Dedicated to the initialisation step of the brick.
+
+        The main objective of this method is to produce the outputs of the
+        bricks (self.outputs) and the associated tags (self.inheritance_dic),
+        if defined here. To work properly this method must return
+        self.make_initResult() object.
+
+        :param is_plugged: the state, linked or not, of the plugs.
+        :returns: a dictionary with requirement, outputs and inheritance_dict.
+        """
+        # Using the inheritance to ProcessMIA class, list_outputs method
+        super(ApplyBiasCorrection, self).list_outputs()
+
+        if self.in_file:
+            if self.output_directory:
+                fname, ext = os.path.splitext(os.path.basename(self.in_file))
+                if ext == ".gz":
+                    fname, ext2 = os.path.splitext(fname)
+                    ext = ext2 + ext
+                self.outputs['out_file'] = os.path.join(
+                    self.output_directory, os.path.split(
+                        self.in_file)[1].replace(ext, '_inu' + ext))
+            else:
+                print('No output_directory was found...!\n')
+                return
+
+        if self.outputs:
+            self.inheritance_dict[self.outputs[
+                'out_file']] = self.in_file
+
+        # Return the requirement, outputs and inheritance_dict
+        return self.make_initResult()
+
+    def run_process_mia(self):
+        """Dedicated to the process launch step of the brick."""
+
+        super(ApplyBiasCorrection, self).run_process_mia()
+
+        in_file = self.in_file
+        out_file = self.out_file
+        bias_image = self.bias_image
+
+        img = nib.load(in_file)
+        data = np.clip(
+            img.get_fdata() * nib.load(bias_image).get_fdata(),
+            a_min=0,
+            a_max=None,
+        )
+        out_img = img.__class__(
+            data.astype(img.get_data_dtype()),
+            img.affine,
+            img.header,
+        )
+
+        out_img.to_filename(out_file)
 
 
 class ArtifactMask(ProcessMIA):
@@ -450,7 +558,8 @@ class Binarize(ProcessMIA):
                          file_extension) = os.path.splitext(file_name)
                         if file_extension == '.gz':
                             (file_name_no_ext_2,
-                             file_extension_2) = os.path.splitext(file_name_no_ext)
+                             file_extension_2) = os.path.splitext(
+                                file_name_no_ext)
                             if file_extension_2 == '.nii':
                                 file_name_no_ext = file_name_no_ext_2
                                 file_extension = '.nii.gz'
@@ -463,7 +572,8 @@ class Binarize(ProcessMIA):
                         print('\nBinarize brick warning: the out_files output '
                               'parameter is the same as the in_files input '
                               'parameter (suffix and prefix are not defined):'
-                              '\n{0} will be overwrited ...'.format(file_name1))
+                              '\n{0} will be overwrited ...'.format(
+                                  file_name1))
 
                         if retval == QMessageBox.YesToAll:
                             flag = False
@@ -506,20 +616,24 @@ class Binarize(ProcessMIA):
 
                     for in_val, out_val in zip(files_name, val):
                         _, fileOval = os.path.split(out_val)
-                        fileOval_no_ext, file_extension = os.path.splitext(fileOval)
+                        fileOval_no_ext, file_extension = os.path.splitext(
+                            fileOval)
 
                         if file_extension == '.gz':
                             (fileOval_no_ext_2,
-                             file_extension_2) = os.path.splitext(fileOval_no_ext)
+                             file_extension_2) = os.path.splitext(
+                                fileOval_no_ext)
                             if file_extension_2 == '.nii':
                                 fileOval_no_ext = fileOval_no_ext_2
 
                         _, fileIval = os.path.split(in_val)
-                        fileIval_no_ext, file_extension = os.path.splitext(fileIval)
+                        fileIval_no_ext, file_extension = os.path.splitext(
+                            fileIval)
 
                         if file_extension == '.gz':
                             (fileIval_no_ext_2,
-                             file_extension_2) = os.path.splitext(fileIval_no_ext)
+                             file_extension_2) = os.path.splitext(
+                                fileIval_no_ext)
                             if file_extension_2 == '.nii':
                                 fileIval_no_ext = fileIval_no_ext_2
 
@@ -560,7 +674,9 @@ class Binarize(ProcessMIA):
                 mask = data > self.thresh_low
                 data[~mask] = 0.0
                 img.header.set_data_dtype("uint8")
-                maskimg = img.__class__(mask.astype("uint8"), img.affine, img.header)
+                maskimg = img.__class__(mask.astype("uint8"),
+                                        img.affine,
+                                        img.header)
 
                 # Image save
                 _, file_name = os.path.split(file_name)
@@ -573,10 +689,10 @@ class Binarize(ProcessMIA):
                         file_extension = '.nii.gz'
 
                 file_out = os.path.join(self.output_directory,
-                                         (self.prefix.strip() +
-                                          file_name_no_ext +
-                                          self.suffix.strip() +
-                                          file_extension))
+                                        (self.prefix.strip() +
+                                         file_name_no_ext +
+                                         self.suffix.strip() +
+                                         file_extension))
                 nib.save(maskimg, file_out)
 
 
@@ -612,13 +728,13 @@ class ConformImage(ProcessMIA):
 
         # Outputs description
         out_file_desc = ('Path of the conformed scan '
-                          '(a pathlike object or string representing a file).')
+                         '(a pathlike object or string representing a file).')
 
         # Inputs traits
         self.add_trait("in_file",
                        File(output=False,
-                                    optional=False,
-                                    desc=in_file_desc))
+                            optional=False,
+                            desc=in_file_desc))
 
         self.add_trait("suffix",
                        traits.String("",
@@ -865,7 +981,8 @@ class Conv_ROI(ProcessMIA):
                 return self.make_initResult()
 
             self.dict4runtime['patient_name'] = patient_name
-            roi_dir = os.path.join(self.output_directory, 'roi_' + patient_name)
+            roi_dir = os.path.join(self.output_directory,
+                                   'roi_' + patient_name)
 
             # if not existing, creates self.output_directory'/roi_'patient_name
             # folder. If already existing, remove old reference ROIs in roi_dir
@@ -874,10 +991,10 @@ class Conv_ROI(ProcessMIA):
                 elts = os.listdir(roi_dir)
                 # filtering only the files
                 files = [f for f in elts
-                             if os.path.isfile(os.path.join(roi_dir, f))]
+                         if os.path.isfile(os.path.join(roi_dir, f))]
                 # filtering only the directories
                 dirs = [d for d in elts
-                             if os.path.isdir(os.path.join(roi_dir, d))]
+                        if os.path.isdir(os.path.join(roi_dir, d))]
                 tmp = False
 
                 if 'convROI_BOLD' in dirs:
@@ -887,10 +1004,10 @@ class Conv_ROI(ProcessMIA):
                                 os.path.join(tmp, 'convROI_BOLD'))
                     print('\nConv_ROI brick:\nA "{}" folder already exists, '
                           'it will be overwritten by this new '
-                          'calculation...'.format(os.path.join(roi_dir,
-                                                               'convROI_BOLD')))
+                          'calculation...'.format(
+                              os.path.join(roi_dir, 'convROI_BOLD')))
 
-                for start_fil in [i[0]+i[1] for i in self.doublet_list]:
+                for start_fil in [i[0] + i[1] for i in self.doublet_list]:
 
                     for fil in files:
 
@@ -898,7 +1015,7 @@ class Conv_ROI(ProcessMIA):
 
                             if not os.path.isdir(tmp):
                                 tmp = tempfile.mktemp(dir=os.path.dirname(
-                                                                       roi_dir))
+                                    roi_dir))
                                 os.mkdir(tmp)
 
                             shutil.move(os.path.join(roi_dir, fil), tmp)
@@ -926,8 +1043,9 @@ class Conv_ROI(ProcessMIA):
             list_out = []
 
             for roi in self.doublet_list:
-                list_out.append(os.path.join(conv_dir,
-                                             'conv' + roi[0] + roi[1] + '.nii'))
+                list_out.append(os.path.join(
+                    conv_dir,
+                    'conv' + roi[0] + roi[1] + '.nii'))
 
             self.outputs['out_images'] = list_out
 
@@ -938,7 +1056,7 @@ class Conv_ROI(ProcessMIA):
         """Dedicated to the process launch step of the brick."""
 
         # No need the next line (we don't use self.process et SPM)
-        #super(Conv_ROI, self).run_process_mia()
+        # super(Conv_ROI, self).run_process_mia()
 
         roi_dir = os.path.join(self.output_directory,
                                'roi_' + self.dict4runtime['patient_name'])
@@ -1090,7 +1208,8 @@ class Enhance(ProcessMIA):
                          file_extension) = os.path.splitext(file_name)
                         if file_extension == '.gz':
                             (file_name_no_ext_2,
-                             file_extension_2) = os.path.splitext(file_name_no_ext)
+                             file_extension_2) = os.path.splitext(
+                                file_name_no_ext)
                             if file_extension_2 == '.nii':
                                 file_name_no_ext = file_name_no_ext_2
                                 file_extension = '.nii.gz'
@@ -1103,7 +1222,8 @@ class Enhance(ProcessMIA):
                         print('\nEnhance brick warning: the out_files output '
                               'parameter is the same as the in_files input '
                               'parameter (suffix and prefix are not defined):'
-                              '\n{0} will be overwrited ...'.format(file_name1))
+                              '\n{0} will be overwrited ...'.format(
+                                  file_name1))
 
                         if retval == QMessageBox.YesToAll:
                             flag = False
@@ -1146,18 +1266,22 @@ class Enhance(ProcessMIA):
 
                     for in_val, out_val in zip(files_name, val):
                         _, fileOval = os.path.split(out_val)
-                        fileOval_no_ext, file_extension = os.path.splitext(fileOval)
+                        fileOval_no_ext, file_extension = os.path.splitext(
+                            fileOval)
                         if file_extension == '.gz':
                             (fileOval_no_ext_2,
-                             file_extension_2) = os.path.splitext(fileOval_no_ext)
+                             file_extension_2) = os.path.splitext(
+                                fileOval_no_ext)
                             if file_extension_2 == '.nii':
                                 fileOval_no_ext = fileOval_no_ext_2
 
                         _, fileIval = os.path.split(in_val)
-                        fileIval_no_ext, file_extension = os.path.splitext(fileIval)
+                        fileIval_no_ext, file_extension = os.path.splitext(
+                            fileIval)
                         if file_extension == '.gz':
                             (fileIval_no_ext_2,
-                             file_extension_2) = os.path.splitext(fileIval_no_ext)
+                             file_extension_2) = os.path.splitext(
+                                fileIval_no_ext)
                             if file_extension_2 == '.nii':
                                 fileIval_no_ext = fileIval_no_ext_2
 
@@ -1261,13 +1385,13 @@ class GradientThreshold(ProcessMIA):
         # Inputs traits
         self.add_trait("in_file",
                        File(output=False,
-                                    optional=False,
-                                    desc=in_file_desc))
+                            optional=False,
+                            desc=in_file_desc))
 
         self.add_trait("seg_file",
                        File(output=False,
-                                    optional=False,
-                                    desc=seg_file_desc))
+                            optional=False,
+                            desc=seg_file_desc))
 
         self.add_trait("suffix",
                        traits.String("_grad",
@@ -1349,8 +1473,8 @@ class GradientThreshold(ProcessMIA):
                                          file_name_no_ext +
                                          self.suffix.strip() +
                                          file_extension))
-                    print('\nGradientThreshold brick warning: the out_file output '
-                          'parameter is the same as the in_file input '
+                    print('\nGradientThreshold brick warning: the out_file'
+                          'output parameter is the same as the in_file input '
                           'parameter (suffix and prefix are not defined):'
                           '\n{0} will be overwrited ...'.format(filename))
 
@@ -1677,6 +1801,168 @@ class Harmonize(ProcessMIA):
                                       self.suffix.strip() +
                                       file_extension))
             nib.save(out_img, file_out)
+
+class IntensityClip(ProcessMIA):
+    """
+    *Clip the intensity range as prescribed by the percentiles
+
+    Remove outliers at both ends of the intensity distribution and fit into a given dtype.
+
+    This interface tries to emulate ANTs workflows' massaging that truncate images into
+    the 0-255 range, and applies percentiles for clipping images.
+    For image registration, normalizing the intensity into a compact range (e.g., uint8)
+    is generally advised.
+
+    To more robustly determine the clipping thresholds, data are removed of spikes
+    with a median filter.
+    Once the thresholds are calculated, the denoised data are thrown away and the thresholds
+    are applied on the original image. (see niworkflow.interface.nibabel.IntensityClip)
+
+    Please, see the complete documentation for the `Threshold brick in the populse.mia_processes website
+    https://populse.github.io/mia_processes/documentation/bricks/preprocess/other/IntensityClip.html
+
+    """
+
+    def __init__(self):
+        """Dedicated to the attributes initialisation / instantiation.
+
+        The input and output plugs are defined here. The special
+        'self.requirement' attribute (optional) is used to define the
+        third-party products necessary for the running of the brick.
+        """
+        # Initialisation of the objects needed for the launch of the brick
+        super(IntensityClip, self).__init__()
+
+        # Third party softwares required for the execution of the brick
+        self.requirement = []
+
+        # Inputs description
+        in_file_desc = '3D file which intensity will be clipped'
+        p_min_desc = 'Percentile for the lower bound'
+        p_max_desc = 'Percentile for the upper bound'
+        dtype_desc = 'Output datatype'
+        invert_desc = 'Finalize by inverting contrast'
+
+        # Outputs description
+        out_file_desc = ('File after clipping')
+
+        # Inputs traits
+        self.add_trait("in_file",
+                       File(output=False,
+                            optional=False,
+                            desc=in_file_desc))
+
+        self.add_trait("p_min",
+                        traits.Float(default_value=10.0,
+                                   output=False,
+                                   optional=True,
+                                   desc=p_min_desc))
+        self.add_trait("p_max",
+                        traits.Float(default_value=99.9,
+                                   output=False,
+                                   optional=True,
+                                   desc=p_max_desc))
+        self.add_trait("nonnegative",
+                       traits.Bool(default_value=True,
+                                     output=False,
+                                     optional=True,
+                                     desc=invert_desc))
+        self.add_trait("dtype",
+                       traits.Enum("int16",
+                                   "float32",
+                                   "uint8",
+                                     output=False,
+                                     optional=True,
+                                     desc=dtype_desc))
+
+        self.add_trait("invert",
+                       traits.Bool(default_value=False,
+                                     output=False,
+                                     optional=True,
+                                     desc=invert_desc))
+
+        # Outputs traits
+        self.add_trait("out_file",
+                       File(output=True,
+                            desc=out_file_desc))
+
+        self.init_default_traits()
+
+    def list_outputs(self, is_plugged=None):
+        """Dedicated to the initialisation step of the brick.
+
+        The main objective of this method is to produce the outputs of the
+        bricks (self.outputs) and the associated tags (self.inheritance_dic),
+        if defined here. To work properly this method must return
+        self.make_initResult() object.
+
+        :param is_plugged: the state, linked or not, of the plugs.
+        :returns: a dictionary with requirement, outputs and inheritance_dict.
+        """
+        # Using the inheritance to ProcessMIA class, list_outputs method
+        super(IntensityClip, self).list_outputs()
+
+        if self.in_file:
+            if self.output_directory:
+                self.outputs['out_file'] = os.path.join(
+                    self.output_directory, os.path.split(
+                        self.in_file)[1].replace('.nii', '_clippep.nii'))
+            else:
+                print('No output_directory was found...!\n')
+                return
+
+        if self.outputs:
+            self.inheritance_dict[self.outputs[
+                'out_file']] = self.in_file
+
+        # Return the requirement, outputs and inheritance_dict
+        return self.make_initResult()
+
+    def run_process_mia(self):
+        """Dedicated to the process launch step of the brick."""
+
+        super(IntensityClip, self).run_process_mia()
+
+        in_file = self.in_file
+        out_file = self.out_file
+        nonnegative = self.nonnegative
+        p_min = self.p_min
+        p_max = self.p_max
+        invert = self.invert
+        dtype = self.dtype
+
+        # Load data
+        img = nib.squeeze_image(nib.load(in_file))
+        if len(img.shape) != 3:
+            raise RuntimeError(f"<{in_file}> is not a 3D file.")
+        data = img.get_fdata(dtype="float32")
+
+        # Calculate stats on denoised version, to preempt outliers from biasing
+        denoised = sim.median_filter(data, footprint=ball(3))
+
+        a_min = np.percentile(
+            denoised[denoised > 0] if nonnegative else denoised,
+            p_min
+        )
+        a_max = np.percentile(
+            denoised[denoised > 0] if nonnegative else denoised,
+            p_max
+        )
+
+        # Clip and cast
+        data = np.clip(data, a_min=a_min, a_max=a_max)
+        data -= data.min()
+        data /= data.max()
+
+        if invert:
+            data = 1.0 - data
+
+        if dtype in ("uint8", "int16"):
+            data = np.round(255 * data).astype(dtype)
+
+        hdr = img.header.copy()
+        hdr.set_data_dtype(dtype)
+        img.__class__(data, img.affine, hdr).to_filename(out_file)
 
 
 class Mask(ProcessMIA):

--- a/python/mia_processes/bricks/reports/processes.py
+++ b/python/mia_processes/bricks/reports/processes.py
@@ -3068,7 +3068,7 @@ def fber(img, headmask, rotmask=None):
         airmask[rotmask > 0] = 0
     bg_mu = np.median(np.abs(img[airmask == 1]) ** 2)
     if bg_mu < 1.0e-3:
-        return 0
+        return -1.0
     return float(fg_mu / bg_mu)
 
 

--- a/python/mia_processes/bricks/reports/processes.py
+++ b/python/mia_processes/bricks/reports/processes.py
@@ -1513,6 +1513,7 @@ class FWHMx(ProcessMIA):
                         'representing a file).')
         combine_desc = 'Combine the final measurements along each axis (a bool).'
         detrend_desc = 'detrend to the specified order (a bool or an int).'
+        classic_desc = 'use classic computation method'
         out_prefix_desc = ('Specify the string to be prepended to the '
                            'filenames of the output image file '
                            '(a string).')
@@ -1546,6 +1547,12 @@ class FWHMx(ProcessMIA):
                                      output=False,
                                      optional=True,
                                      desc=detrend_desc))
+
+        self.add_trait("classic",
+                       traits.String('-ShowMeClassicFWHM',
+                                     output=False,
+                                     optional=True,
+                                     desc=classic_desc))
 
         self.add_trait("out_prefix",
                        traits.String('fwhm_',
@@ -1624,6 +1631,7 @@ class FWHMx(ProcessMIA):
         self.process.mask = self.mask_file
         self.process.combine = self.combine
         self.process.detrend = self.detrend
+        self.process.classic = '-ShowMeClassicFWHM'
         self.process.out_file = self.out_file
 
         if self.out_prefix:

--- a/python/mia_processes/bricks/reports/processes.py
+++ b/python/mia_processes/bricks/reports/processes.py
@@ -79,7 +79,7 @@ from scipy.stats import kurtosis  # pylint: disable=E0611
 import shutil
 from skimage.transform import resize
 
-DIETRICH_FACTOR = 0.6551364 #1.0 / sqrt(2 / (4 - pi))
+DIETRICH_FACTOR = 0.6551364  # 1.0 / sqrt(2 / (4 - pi))
 FSL_FAST_LABELS = {"csf": 1, "gm": 2, "wm": 3, "bg": 0}
 RAS_AXIS_ORDER = {"x": 0, "y": 1, "z": 2}
 
@@ -378,7 +378,8 @@ class AnatIQMs(ProcessMIA):
 
         has_stats = False
         if has_in_noinu and has_pvms and has_airmask:
-            erode = np.all(np.array(imnii.header.get_zooms()[:3], dtype=np.float32) < 1.9)
+            erode = np.all(np.array(imnii.header.get_zooms()[:3],
+                                    dtype=np.float32) < 1.9)
 
             # Summary stats
             stats = summary_stats(inudata, pvmdata, airdata, erode=erode)
@@ -486,7 +487,8 @@ class AnatIQMs(ProcessMIA):
                 "z": int(inudata.shape[2]),
             }
             results_dict["spacing"] = {
-                i: float(v) for i, v in zip(["x", "y", "z"], imnii.header.get_zooms()[:3])
+                i: float(v) for i, v in zip(["x", "y", "z"],
+                                            imnii.header.get_zooms()[:3])
             }
 
             try:
@@ -567,8 +569,8 @@ class BoldIQMs(ProcessMIA):
         # Inputs description
         in_epi_desc = ('EPI input image (a pathlike object or string '
                        'representing a file).')
-        in_hmc_desc = ('Motion corrected input image (a pathlike object or string '
-                       'representing a file).')
+        in_hmc_desc = ('Motion corrected input image (a pathlike object or'
+                       'string representing a file).')
         in_tsnr_desc = ('tSNR input volume (a pathlike object or string '
                         'representing a file).')
         in_mask_desc = ('Input mask image (a pathlike object or string '
@@ -583,9 +585,9 @@ class BoldIQMs(ProcessMIA):
         in_dvars_file_desc = ('DVARS file (a pathlike object or string '
                               'representing a file).')
         in_fd_file_desc = ('FD file (a pathlike object or string '
-                              'representing a file).')
+                           'representing a file).')
         in_spikes_file_desc = ('Spikes file (a pathlike object or string '
-                              'representing a file).')
+                               'representing a file).')
         in_gcor_desc = 'Global correlation value (a float)'
         in_dummy_TRs_desc = 'Number of dummy scans (an int)'
 
@@ -779,7 +781,8 @@ class BoldIQMs(ProcessMIA):
             results_dict["gsr"] = {}
             epidir = ["x", "y"]
             for axis in epidir:
-                results_dict["gsr"][axis] = gsr(epidata, mskdata, direction=axis)
+                results_dict["gsr"][axis] = gsr(epidata, mskdata,
+                                                direction=axis)
 
         # aor
         if self.in_outliers_file:
@@ -915,7 +918,7 @@ class BoldIQMs(ProcessMIA):
                 print("\nError with fd file: ", e)
                 pass
             else:
-                for i in range(0,len(spikes_data[:, 0])):
+                for i in range(0, len(spikes_data[:, 0])):
                     spike_name = "vec_spikes_" + str(i)
                     results_dict[spike_name] = list(spikes_data[i, :])
 
@@ -971,7 +974,7 @@ class CarpetParcellation(ProcessMIA):
         segmentation_desc = ('EPI segmentation (a pathlike object or string '
                              'representing a file).')
         brainmask_desc = ('Brain mask (a pathlike object or string '
-                        'representing a file).')
+                          'representing a file).')
 
         out_prefix_desc = ('Specify the string to be prepended to the '
                            'segmentation filename of the output file (a string).')
@@ -1130,16 +1133,22 @@ class ComputeDVARS(ProcessMIA):
                         'representing a file).')
         in_mask_desc = ('Brain mask (a pathlike object or string '
                         'representing a file).')
-        remove_zero_variance_desc = 'Remove voxels with zero variance (a bool).'
-        intensity_normalization_desc = 'Divide value in each voxel at each timepoint ' \
-                                  'by the median calculated across all voxels' \
-                                  'and timepoints within the mask (if specified)' \
-                                  'and then multiply by the value specified by' \
-                                  'this parameter. By using the default (1000)' \
-                                  'output DVARS will be expressed in ' \
-                                  'x10 % BOLD units compatible with Power et al.' \
-                                  '2012. Set this to 0 to disable intensity' \
-                                  'normalization altogether. (a float)'
+        remove_zero_variance_desc = ('Remove voxels with zero variance'
+                                     '(a bool).')
+        intensity_normalization_desc = ('Divide value in each voxel at each'
+                                        'timepoint by the median calculated'
+                                        'across all voxels and timepoints'
+                                        'within the mask (if specified) and'
+                                        'then multiply by the value specified'
+                                        'by this parameter.'
+                                        'By using the default (1000)'
+                                        'output DVARS will be expressed in '
+                                        'x10 % BOLD units compatible'
+                                        'with Power et al.2012.'
+                                        'Set this to 0 to disable intensity'
+                                        'normalization altogether. (a float)')
+        variance_tol_desc = ('Maximum variance to consider "close to" zero'
+                             'for the purposes of removal')
         out_prefix_desc = ('Specify the string to be prepended to the '
                            'filename of the output file (a string).')
 
@@ -1169,6 +1178,12 @@ class ComputeDVARS(ProcessMIA):
                                     optional=True,
                                     output=False,
                                     desc=intensity_normalization_desc))
+
+        self.add_trait("variance_tol",
+                       traits.Float(0.0000001000,
+                                    optional=True,
+                                    output=False,
+                                    desc=variance_tol_desc))
 
         self.add_trait("out_prefix",
                        traits.String('dvars_',
@@ -1256,14 +1271,13 @@ class ComputeDVARS(ProcessMIA):
                                  '.out'))
 
         # Load data
-        func = nb.load(self.in_file).get_fdata(dtype=np.float32)
-        mask = np.asanyarray(nb.load(self.in_mask).dataobj).astype(np.uint8)
+        func = np.float32(nb.load(self.in_file).dataobj)
+        mask = np.bool_(nb.load(self.in_mask).dataobj)
 
         if len(func.shape) != 4:
             raise RuntimeError("Input fMRI dataset should be 4-dimensional")
 
-        idx = np.where(mask > 0)
-        mfunc = func[idx[0], idx[1], idx[2], :]
+        mfunc = func[mask]
 
         if self.intensity_normalization != 0:
             mfunc = (mfunc / np.median(mfunc)) * self.intensity_normalization
@@ -1271,17 +1285,19 @@ class ComputeDVARS(ProcessMIA):
         # Robust standard deviation (we are using "lower" interpolation
         # because this is what FSL is doing
         func_sd = (
-                          np.percentile(mfunc, 75, axis=1, interpolation="lower")
-                          - np.percentile(mfunc, 25, axis=1, interpolation="lower")
-                  ) / 1.349
+            np.percentile(mfunc, 75, axis=1, interpolation="lower")
+            - np.percentile(mfunc, 25, axis=1, interpolation="lower")
+        ) / 1.349
 
         if self.remove_zero_variance:
-            mfunc = mfunc[func_sd != 0, :]
-            func_sd = func_sd[func_sd != 0]
+            zero_variance_voxels = func_sd > self.variance_tol
+            mfunc = mfunc[zero_variance_voxels, :]
+            func_sd = func_sd[zero_variance_voxels]
 
         # Compute (non-robust) estimate of lag-1 autocorrelation
         ar1 = np.apply_along_axis(
-            AR_est_YW, 1, regress_poly(0, mfunc, remove_mean=True)[0].astype(np.float32), 1
+            _AR_est_YW, 1,
+            regress_poly(0, mfunc, remove_mean=True)[0].astype(np.float32), 1
         )[:, 0]
 
         # Compute (predicted) standard deviation of temporal difference time series
@@ -3317,7 +3333,7 @@ def snr_dietrich(mu_fg, mad_air=0.0, sigma_air=1.0):
     """
     if mad_air > 1.0:
         return float(DIETRICH_FACTOR * mu_fg / mad_air)
-    
+
     return float(DIETRICH_FACTOR * mu_fg / sigma_air) if sigma_air > 1e-3 else -1.0
 
 
@@ -3384,7 +3400,7 @@ def summary_stats(img, pvms, airmask=None, erode=True):
                     "n": nvox,
                 }
                 continue
-        
+    
         output[k] = {
             "mean": float(img[mask == 1].mean()),
             "stdv": float(img[mask == 1].std()),
@@ -3473,3 +3489,10 @@ def _robust_zscore(data):
     return (data - np.atleast_2d(np.median(data, axis=1)).T) / np.atleast_2d(
         data.std(axis=1)
     ).T
+
+
+def _AR_est_YW(x, order, rxx=None):
+    """Retrieve AR coefficients while dropping the sig_sq return value"""
+    from nitime.algorithms import AR_est_YW
+
+    return AR_est_YW(x, order, rxx=rxx)[0]

--- a/python/mia_processes/bricks/reports/reporting.py
+++ b/python/mia_processes/bricks/reports/reporting.py
@@ -245,11 +245,11 @@ class MRIQC_anat_report(ProcessMIA):
         #        should be found to retrieve them automatically or to put them
         #        in the input parameters of the brick:
         # Site
-        if self.dict4runtime['Site'] in ("", "Undefined"):
+        if self.dict4runtime['Site'] in ("", "Undefined", None):
             self.dict4runtime['Site'] = 'Grenoble University Hospital - CLUNI'
 
         # MriScanner
-        if self.dict4runtime['Spectro'] in ("", "Undefined"):
+        if self.dict4runtime['Spectro'] in ("", "Undefined", None):
             self.dict4runtime['Spectro'] = 'Philips Achieva 3.0T TX'
 
         # Generate an output name
@@ -888,11 +888,11 @@ class MRIQC_func_report(ProcessMIA):
         #        should be found to retrieve them automatically or to put them
         #        in the input parameters of the brick:
         # Site
-        if self.dict4runtime['Site'] in ("", "Undefined"):
+        if self.dict4runtime['Site'] in ("", "Undefined", None):
             self.dict4runtime['Site'] = 'Grenoble University Hospital - CLUNI'
 
         # MriScanner
-        if self.dict4runtime['Spectro'] in ("", "Undefined"):
+        if self.dict4runtime['Spectro'] in ("", "Undefined", None):
             self.dict4runtime['Spectro'] = 'Philips Achieva 3.0T TX'
 
         # Generate an output name

--- a/python/mia_processes/bricks/reports/reporting.py
+++ b/python/mia_processes/bricks/reports/reporting.py
@@ -1182,11 +1182,11 @@ class MRIQC_func_report(ProcessMIA):
                      "Differences in Resting-State FMRI</i>, Brain Conn "
                      "3(4):339-352, 2013."
                      ],
-            "aor": ["AFNI s outlier ratio",
+            "aor": ["AFNI's outlier ratio",
                      "{:.2e}",
                      None
                      ],
-            "aqi": ["AFNI s quality index",
+            "aqi": ["AFNI's quality index",
                      "{:.2e}",
                      None
                      ]

--- a/python/mia_processes/bricks/reports/reporting.py
+++ b/python/mia_processes/bricks/reports/reporting.py
@@ -245,11 +245,11 @@ class MRIQC_anat_report(ProcessMIA):
         #        should be found to retrieve them automatically or to put them
         #        in the input parameters of the brick:
         # Site
-        if self.dict4runtime['Site'] in ("", "Undefined", None):
+        if self.dict4runtime['Site'] in ("", "Undefined"):
             self.dict4runtime['Site'] = 'Grenoble University Hospital - CLUNI'
 
         # MriScanner
-        if self.dict4runtime['Spectro'] in ("", "Undefined", None):
+        if self.dict4runtime['Spectro'] in ("", "Undefined"):
             self.dict4runtime['Spectro'] = 'Philips Achieva 3.0T TX'
 
         # Generate an output name

--- a/python/mia_processes/bricks/reports/reporting.py
+++ b/python/mia_processes/bricks/reports/reporting.py
@@ -1181,6 +1181,14 @@ class MRIQC_func_report(ProcessMIA):
                      "Saad et al., <i>Correcting Brain-Wide Correlation "
                      "Differences in Resting-State FMRI</i>, Brain Conn "
                      "3(4):339-352, 2013."
+                     ],
+            "aor": ["AFNI s outlier ratio",
+                     "{:.2e}",
+                     None
+                     ],
+            "aqi": ["AFNI s quality index",
+                     "{:.2e}",
+                     None
                      ]
         }
 

--- a/python/mia_processes/pipelines/preprocess/__init__.py
+++ b/python/mia_processes/pipelines/preprocess/__init__.py
@@ -13,6 +13,7 @@ from .anat_headmask_pipeline import Anat_headmask_pipeline
 from .anat_mni_tpms_pipeline import Anat_mni_tpms_pipeline
 from .anat_mriqc_pipeline import Anat_mriqc_pipeline
 from .anat_skullstrip_pipeline import Anat_skullstrip_pipeline
+from .anat_skullstrip_synthstrip_pipeline import Anat_skullstrip_synthstrip_pipeline
 from .anat_spatial_norm import Anat_spatial_norm
 from .bold_hmc_pipeline import Bold_hmc_pipeline
 from .bold_mni_align import Bold_mni_align

--- a/python/mia_processes/pipelines/preprocess/anat_airmask_pipeline.py
+++ b/python/mia_processes/pipelines/preprocess/anat_airmask_pipeline.py
@@ -6,10 +6,14 @@ class Anat_airmask_pipeline(Pipeline):
 
     def pipeline_definition(self):
         # nodes
-        self.add_process("rotationmask", "mia_processes.bricks.preprocess.others.processing.RotationMask")
-        self.add_process("applytransforms", "mia_processes.bricks.preprocess.ants.processes.ApplyTransforms")
-        self.add_process("artifactmask", "mia_processes.bricks.preprocess.others.processing.ArtifactMask")
-        self.add_process("template", "mia_processes.bricks.preprocess.others.processing.Template")
+        self.add_process("rotationmask", "mia_processes.bricks.preprocess."
+                         "others.processing.RotationMask")
+        self.add_process("applytransforms", "mia_processes.bricks.preprocess."
+                         "ants.processes.ApplyTransforms")
+        self.add_process("artifactmask", "mia_processes.bricks.preprocess."
+                         "others.processing.ArtifactMask")
+        self.add_process("template", "mia_processes.bricks.preprocess."
+                         "others.processing.Template")
         self.nodes["template"].process.in_template = 'MNI152NLin2009cAsym'
         self.nodes["template"].process.resolution = 1
         self.nodes["template"].process.suffix = 'mask'
@@ -19,20 +23,29 @@ class Anat_airmask_pipeline(Pipeline):
         # links
         self.export_parameter("artifactmask", "in_file", is_optional=False)
         self.add_link("in_file->rotationmask.in_file")
-        self.export_parameter("applytransforms", "reference_image", "in_mask", is_optional=False)
-        self.export_parameter("applytransforms", "transforms", "inverse_composite_transform", is_optional=False)
+        self.export_parameter("applytransforms", "reference_image",
+                              "in_mask", is_optional=False)
+        self.export_parameter("applytransforms", "transforms",
+                              "inverse_composite_transform", is_optional=False)
         self.export_parameter("artifactmask", "head_mask", is_optional=False)
-        self.export_parameter("rotationmask", "out_file", "out_rot_mask", is_optional=False)
-        self.add_link("rotationmask.out_file->artifactmask.rot_mask")
-        self.add_link("applytransforms.output_image->artifactmask.nasion_post_mask")
-        self.export_parameter("artifactmask", "out_hat_mask", is_optional=False)
-        self.export_parameter("artifactmask", "out_art_mask", is_optional=False)
-        self.export_parameter("artifactmask", "out_air_mask", is_optional=False)
+        self.export_parameter("rotationmask", "out_file",
+                              "out_rot_mask", is_optional=False)
+        self.add_link("rotationmask.out_file->"
+                      "artifactmask.rot_mask")
+        self.add_link("applytransforms.output_image->"
+                      "artifactmask.nasion_post_mask")
+        self.export_parameter("artifactmask", "out_hat_mask",
+                              is_optional=False)
+        self.export_parameter("artifactmask", "out_art_mask",
+                              is_optional=False)
+        self.export_parameter("artifactmask", "out_air_mask",
+                              is_optional=False)
         self.add_link("template.template->applytransforms.input_image")
 
         # parameters order
-
-        self.reorder_traits(("in_file", "in_mask", "inverse_composite_transform", "head_mask", "out_hat_mask", "out_art_mask", "out_air_mask"))
+        self.reorder_traits(("in_file", "in_mask",
+                             "inverse_composite_transform", "head_mask",
+                             "out_hat_mask", "out_art_mask", "out_air_mask"))
 
         # default and initial values
         self.template = 'MNI152NLin2009cAsym'

--- a/python/mia_processes/pipelines/preprocess/anat_airmask_pipeline.py
+++ b/python/mia_processes/pipelines/preprocess/anat_airmask_pipeline.py
@@ -14,6 +14,7 @@ class Anat_airmask_pipeline(Pipeline):
         self.nodes["template"].process.resolution = 1
         self.nodes["template"].process.suffix = 'mask'
         self.nodes["template"].process.desc = 'head'
+        self.nodes["applytransforms"].process.interpolation = 'MultiLabel'
 
         # links
         self.export_parameter("artifactmask", "in_file", is_optional=False)

--- a/python/mia_processes/pipelines/preprocess/anat_headmask_pipeline.py
+++ b/python/mia_processes/pipelines/preprocess/anat_headmask_pipeline.py
@@ -6,18 +6,27 @@ class Anat_headmask_pipeline(Pipeline):
 
     def pipeline_definition(self):
         # nodes
-        self.add_process("denoise", "mia_processes.bricks.preprocess.dipy.processes.Denoise")
-        self.add_process("enhance", "mia_processes.bricks.preprocess.others.processing.Enhance")
-        self.add_process("gradient_threshold", "mia_processes.bricks.preprocess.others.processing.GradientThreshold")
+        self.add_process("denoise",
+                         "mia_processes.bricks.preprocess."
+                         "dipy.processes.Denoise")
+        self.add_process("enhance",
+                         "mia_processes.bricks.preprocess."
+                         "others.processing.Enhance")
+        self.add_process("gradient_threshold",
+                         "mia_processes.bricks.preprocess."
+                         "others.processing.GradientThreshold")
 
         # links
-        self.export_parameter("denoise", "in_file_snr", "in_file", is_optional=False)
+        self.export_parameter("denoise", "in_file_snr", "in_file",
+                              is_optional=False)
         self.add_link("in_file->enhance.in_files")
-        self.export_parameter("gradient_threshold", "seg_file", is_optional=False)
+        self.export_parameter("gradient_threshold", "seg_file",
+                              is_optional=False)
         self.add_link("seg_file->denoise.seg_file")
         self.add_link("denoise.out_file->gradient_threshold.in_file")
         self.add_link("enhance.out_files->denoise.in_file")
-        self.export_parameter("gradient_threshold", "out_file", is_optional=False)
+        self.export_parameter("gradient_threshold", "out_file",
+                              is_optional=False)
 
         # parameters order
 

--- a/python/mia_processes/pipelines/preprocess/anat_mni_tpms_pipeline.py
+++ b/python/mia_processes/pipelines/preprocess/anat_mni_tpms_pipeline.py
@@ -6,47 +6,65 @@ class Anat_mni_tpms_pipeline(Pipeline):
 
     def pipeline_definition(self):
         # nodes
-        self.add_process("template_CSF", "mia_processes.bricks.preprocess.others.processing.Template")
+        self.add_process("template_CSF",
+                         "mia_processes.bricks.preprocess."
+                         "others.processing.Template")
         self.nodes["template_CSF"].process.in_template = 'MNI152NLin2009cAsym'
         self.nodes["template_CSF"].process.resolution = 1
         self.nodes["template_CSF"].process.suffix = 'probseg'
         self.nodes["template_CSF"].process.label = 'CSF'
-        self.add_process("applytransforms_CSF", "mia_processes.bricks.preprocess.ants.processes.ApplyTransforms")
+        self.add_process("applytransforms_CSF",
+                         "mia_processes.bricks.preprocess."
+                         "ants.processes.ApplyTransforms")
         self.nodes["applytransforms_CSF"].process.out_prefix = 'csf_'
-        self.add_process("template_GM", "mia_processes.bricks.preprocess.others.processing.Template")
+        self.add_process("template_GM",
+                         "mia_processes.bricks.preprocess"
+                         ".others.processing.Template")
         self.nodes["template_GM"].process.in_template = 'MNI152NLin2009cAsym'
         self.nodes["template_GM"].process.resolution = 1
         self.nodes["template_GM"].process.suffix = 'probseg'
         self.nodes["template_GM"].process.label = 'GM'
-        self.add_process("template_WM", "mia_processes.bricks.preprocess.others.processing.Template")
+        self.add_process("template_WM",
+                         "mia_processes.bricks.preprocess."
+                         "others.processing.Template")
         self.nodes["template_WM"].process.in_template = 'MNI152NLin2009cAsym'
         self.nodes["template_WM"].process.resolution = 1
         self.nodes["template_WM"].process.suffix = 'probseg'
         self.nodes["template_WM"].process.label = 'WM'
-        self.add_process("applytransforms_WM", "mia_processes.bricks.preprocess.ants.processes.ApplyTransforms")
+        self.add_process("applytransforms_WM",
+                         "mia_processes.bricks.preprocess."
+                         "ants.processes.ApplyTransforms")
         self.nodes["applytransforms_WM"].process.out_prefix = 'wm_'
-        self.add_process("applytransforms_GM", "mia_processes.bricks.preprocess.ants.processes.ApplyTransforms")
+        self.add_process("applytransforms_GM",
+                         "mia_processes.bricks.preprocess."
+                         "ants.processes.ApplyTransforms")
         self.nodes["applytransforms_GM"].process.out_prefix = 'gm_'
-        self.add_process("files_to_list", "mia_processes.bricks.tools.tools.Files_To_List")
+        self.add_process("files_to_list",
+                         "mia_processes.bricks.tools.tools.Files_To_List")
 
         # links
-        self.export_parameter("applytransforms_CSF", "reference_image", "in_ras", is_optional=False)
+        self.export_parameter("applytransforms_CSF", "reference_image",
+                              "in_ras", is_optional=False)
         self.add_link("in_ras->applytransforms_GM.reference_image")
         self.add_link("in_ras->applytransforms_WM.reference_image")
-        self.export_parameter("applytransforms_WM", "transforms", "inverse_composite_transform", is_optional=False)
-        self.add_link("inverse_composite_transform->applytransforms_CSF.transforms")
-        self.add_link("inverse_composite_transform->applytransforms_GM.transforms")
+        self.export_parameter("applytransforms_WM", "transforms",
+                              "inverse_composite_transform", is_optional=False)
+        self.add_link("inverse_composite_transform->"
+                      "applytransforms_CSF.transforms")
+        self.add_link("inverse_composite_transform->"
+                      "applytransforms_GM.transforms")
         self.add_link("template_CSF.template->applytransforms_CSF.input_image")
         self.add_link("applytransforms_CSF.output_image->files_to_list.file1")
         self.add_link("template_GM.template->applytransforms_GM.input_image")
         self.add_link("template_WM.template->applytransforms_WM.input_image")
         self.add_link("applytransforms_WM.output_image->files_to_list.file3")
         self.add_link("applytransforms_GM.output_image->files_to_list.file2")
-        self.export_parameter("files_to_list", "file_list", "mni_tpms", is_optional=False)
+        self.export_parameter("files_to_list", "file_list",
+                              "mni_tpms", is_optional=False)
 
         # parameters order
-
-        self.reorder_traits(("in_ras", "inverse_composite_transform", "mni_tpms"))
+        self.reorder_traits(("in_ras", "inverse_composite_transform",
+                             "mni_tpms"))
 
         # default and initial values
         self.template = 'MNI152NLin2009cAsym'

--- a/python/mia_processes/pipelines/preprocess/anat_mriqc_pipeline.py
+++ b/python/mia_processes/pipelines/preprocess/anat_mriqc_pipeline.py
@@ -89,7 +89,7 @@ class Anat_mriqc_pipeline(Pipeline):
         # default and initial values
         self.nodes["conformimage"].process.suffix = ' '
         self.nodes["conformimage"].process.prefix = ' '
-        self.nodes["list_to_file"].process.index_filter = [2]
+        self.nodes["list_to_file"].process.index_filter = [3]
         self.nodes["harmonize"].process.prefix = ' '
 
         # nodes positions

--- a/python/mia_processes/pipelines/preprocess/anat_mriqc_pipeline.py
+++ b/python/mia_processes/pipelines/preprocess/anat_mriqc_pipeline.py
@@ -9,7 +9,7 @@ class Anat_mriqc_pipeline(Pipeline):
         self.add_process("conformimage",
                          "mia_processes.bricks.preprocess.others.processing.ConformImage")
         self.add_process("anat_skullstrip_pipeline",
-                         "mia_processes.pipelines.preprocess.anat_skullstrip_pipeline.Anat_skullstrip_pipeline")
+                         "mia_processes.pipelines.preprocess.anat_skullstrip_synthstrip_pipeline.Anat_skullstrip_synthstrip_pipeline")
         self.add_process("segment",
                          "mia_processes.bricks.preprocess.fsl.processes.Segment")
         self.add_process("anat_spatial_norm",
@@ -42,18 +42,19 @@ class Anat_mriqc_pipeline(Pipeline):
         self.add_link("conformimage.out_file->fwhmx.in_file")
         self.add_link("conformimage.out_file->anat_mni_tpms_pipeline.in_ras")
         self.add_link("conformimage.out_file->anat_airmask_pipeline.in_file")
-        self.add_link("anat_skullstrip_pipeline.out_file->segment.in_file")
-        self.add_link("anat_skullstrip_pipeline.out_mask->fwhmx.mask_file")
+        self.add_link("anat_skullstrip_pipeline.out_brain->segment.in_file")
         self.add_link(
-            "anat_skullstrip_pipeline.out_mask->anat_spatial_norm.moving_mask")
+            "anat_skullstrip_pipeline.out_mask_synthstrip->fwhmx.mask_file")
         self.add_link(
-            "anat_skullstrip_pipeline.out_mask->anat_airmask_pipeline.in_mask")
+            "anat_skullstrip_pipeline.out_mask_synthstrip->anat_spatial_norm.moving_mask")
         self.add_link(
-            "anat_skullstrip_pipeline.bias_corrected->harmonize.in_file")
+            "anat_skullstrip_pipeline.out_mask_synthstrip->anat_airmask_pipeline.in_mask")
         self.add_link(
-            "anat_skullstrip_pipeline.bias_corrected->anat_headmask.in_file")
+            "anat_skullstrip_pipeline.out_corrected->harmonize.in_file")
         self.add_link(
-            "anat_skullstrip_pipeline.bias_corrected->anat_spatial_norm.moving_image")
+            "anat_skullstrip_pipeline.out_corrected->anat_headmask.in_file")
+        self.add_link(
+            "anat_skullstrip_pipeline.out_corrected->anat_spatial_norm.moving_image")
         self.add_link("anat_skullstrip_pipeline.bias_image->anatiqms.in_inu")
         self.add_link("segment.tissue_class_map->anatiqms.segmentation")
         self.add_link("segment.partial_volume_files->list_to_file.file_list")

--- a/python/mia_processes/pipelines/preprocess/anat_mriqc_pipeline.py
+++ b/python/mia_processes/pipelines/preprocess/anat_mriqc_pipeline.py
@@ -14,8 +14,8 @@ class Anat_mriqc_pipeline(Pipeline):
                          "mia_processes.bricks.preprocess.fsl.processes.Segment")
         self.add_process("anat_spatial_norm",
                          "mia_processes.pipelines.preprocess.anat_spatial_norm.Anat_spatial_norm")
-        self.add_process("anat_headmask_pipeline",
-                         "mia_processes.pipelines.preprocess.anat_headmask_pipeline.Anat_headmask_pipeline")
+        self.add_process("anat_headmask",
+                         "mia_processes.bricks.preprocess.fsl.SurfacesExtraction")
         self.add_process("anat_airmask_pipeline",
                          "mia_processes.pipelines.preprocess.anat_airmask_pipeline.Anat_airmask_pipeline")
         self.add_process("anat_mni_tpms_pipeline",
@@ -51,12 +51,10 @@ class Anat_mriqc_pipeline(Pipeline):
         self.add_link(
             "anat_skullstrip_pipeline.bias_corrected->harmonize.in_file")
         self.add_link(
-            "anat_skullstrip_pipeline.bias_corrected->anat_headmask_pipeline.in_file")
+            "anat_skullstrip_pipeline.bias_corrected->anat_headmask.in_file")
         self.add_link(
             "anat_skullstrip_pipeline.bias_corrected->anat_spatial_norm.moving_image")
         self.add_link("anat_skullstrip_pipeline.bias_image->anatiqms.in_inu")
-        self.add_link(
-            "segment.tissue_class_map->anat_headmask_pipeline.seg_file")
         self.add_link("segment.tissue_class_map->anatiqms.segmentation")
         self.add_link("segment.partial_volume_files->list_to_file.file_list")
         self.add_link("segment.partial_volume_files->anatiqms.pvms")
@@ -67,8 +65,8 @@ class Anat_mriqc_pipeline(Pipeline):
         self.add_link(
             "anat_spatial_norm.warped_image->mriqc_anat_report.norm_anat")
         self.add_link(
-            "anat_headmask_pipeline.out_file->anat_airmask_pipeline.head_mask")
-        self.add_link("anat_headmask_pipeline.out_file->anatiqms.headmask")
+            "anat_headmask.outskin_mask_file->anat_airmask_pipeline.head_mask")
+        self.add_link("anat_headmask.outskin_mask_file->anatiqms.headmask")
         self.add_link("anat_airmask_pipeline.out_hat_mask->anatiqms.hatmask")
         self.add_link("anat_airmask_pipeline.out_art_mask->anatiqms.artmask")
         self.add_link("anat_airmask_pipeline.out_air_mask->anatiqms.airmask")
@@ -96,11 +94,10 @@ class Anat_mriqc_pipeline(Pipeline):
         self.node_position = {
             "conformimage": (-266.294964300051, 665.2984755165728),
             "inputs": (-760.1707537491396, 306.60591462332025),
-            "anat_skullstrip_pipeline": (
-            -318.30359196600546, 123.01959076904758),
+            "anat_skullstrip_pipeline": (-318.30359196600546, 123.01959076904758),
             "segment": (-82.8528, -26.389119999999984),
             "anat_spatial_norm": (122.1775299994049, 474.3922141023147),
-            "anat_headmask_pipeline": (239.62046769206347, 245.85271538452383),
+            "anat_headmask": (239.62046769206347, 245.85271538452383),
             "anat_airmask_pipeline": (512.8535576922617, -39.083212461309614),
             "anat_mni_tpms_pipeline": (23.313110769047682, 1180.4801720512571),
             "anatiqms": (878.0130611266952, 880.9613282881348),
@@ -118,7 +115,7 @@ class Anat_mriqc_pipeline(Pipeline):
             "anat_skullstrip_pipeline": (179.21875, 180.0),
             "segment": (223.25, 145.0),
             "anat_spatial_norm": (377.796875, 635.0),
-            "anat_headmask_pipeline": (176.640625, 110.0),
+            "anat_headmask": (176.640625, 110.0),
             "anat_airmask_pipeline": (276.828125, 250.0),
             "anat_mni_tpms_pipeline": (256.109375, 215.0),
             "anatiqms": (152.203125, 460.0),

--- a/python/mia_processes/pipelines/preprocess/anat_mriqc_pipeline.py
+++ b/python/mia_processes/pipelines/preprocess/anat_mriqc_pipeline.py
@@ -7,66 +7,76 @@ class Anat_mriqc_pipeline(Pipeline):
     def pipeline_definition(self):
         # nodes
         self.add_process("conformimage",
-                         "mia_processes.bricks.preprocess.others.processing.ConformImage")
+                         "mia_processes.bricks.preprocess."
+                         "others.processing.ConformImage")
         self.add_process("anat_skullstrip_pipeline",
-                         "mia_processes.pipelines.preprocess.anat_skullstrip_synthstrip_pipeline.Anat_skullstrip_synthstrip_pipeline")
+                         "mia_processes.pipelines.preprocess."
+                         "anat_skullstrip_synthstrip_pipeline."
+                         "Anat_skullstrip_synthstrip_pipeline")
         self.add_process("segment",
-                         "mia_processes.bricks.preprocess.fsl.processes.Segment")
+                         "mia_processes.bricks.preprocess."
+                         "fsl.processes.Segment")
         self.add_process("anat_spatial_norm",
-                         "mia_processes.pipelines.preprocess.anat_spatial_norm.Anat_spatial_norm")
+                         "mia_processes.pipelines.preprocess."
+                         "anat_spatial_norm.Anat_spatial_norm")
         self.add_process("anat_headmask",
-                         "mia_processes.bricks.preprocess.fsl.SurfacesExtraction")
+                         "mia_processes.bricks.preprocess"
+                         ".fsl.SurfacesExtraction")
         self.add_process("anat_airmask_pipeline",
-                         "mia_processes.pipelines.preprocess.anat_airmask_pipeline.Anat_airmask_pipeline")
+                         "mia_processes.pipelines.preprocess."
+                         "anat_airmask_pipeline.Anat_airmask_pipeline")
         self.add_process("anat_mni_tpms_pipeline",
-                         "mia_processes.pipelines.preprocess.anat_mni_tpms_pipeline.Anat_mni_tpms_pipeline")
+                         "mia_processes.pipelines.preprocess."
+                         "anat_mni_tpms_pipeline.Anat_mni_tpms_pipeline")
         self.add_process("anatiqms",
                          "mia_processes.bricks.reports.processes.AnatIQMs")
         self.add_process("harmonize",
-                         "mia_processes.bricks.preprocess.others.processing.Harmonize")
+                         "mia_processes.bricks.preprocess."
+                         "others.processing.Harmonize")
         self.add_process("fwhmx",
                          "mia_processes.bricks.reports.processes.FWHMx")
         self.nodes["fwhmx"].plugs["detrend"].optional = True
         self.add_process("list_to_file",
                          "mia_processes.bricks.tools.tools.List_To_File")
         self.add_process("mriqc_anat_report",
-                         "mia_processes.bricks.reports.reporting.MRIQC_anat_report")
+                         "mia_processes.bricks.reports."
+                         "reporting.MRIQC_anat_report")
 
         # links
         self.export_parameter("conformimage", "in_file", "anat_file",
                               is_optional=False)
         self.add_link("anat_file->mriqc_anat_report.anat")
-        self.add_link(
-            "conformimage.out_file->anat_skullstrip_pipeline.in_file")
+        self.add_link("conformimage.out_file->"
+                      "anat_skullstrip_pipeline.in_file")
         self.add_link("conformimage.out_file->anatiqms.in_ras")
         self.add_link("conformimage.out_file->fwhmx.in_file")
         self.add_link("conformimage.out_file->anat_mni_tpms_pipeline.in_ras")
         self.add_link("conformimage.out_file->anat_airmask_pipeline.in_file")
         self.add_link("anat_skullstrip_pipeline.out_brain->segment.in_file")
-        self.add_link(
-            "anat_skullstrip_pipeline.out_mask_synthstrip->fwhmx.mask_file")
-        self.add_link(
-            "anat_skullstrip_pipeline.out_mask_synthstrip->anat_spatial_norm.moving_mask")
-        self.add_link(
-            "anat_skullstrip_pipeline.out_mask_synthstrip->anat_airmask_pipeline.in_mask")
-        self.add_link(
-            "anat_skullstrip_pipeline.out_corrected->harmonize.in_file")
-        self.add_link(
-            "anat_skullstrip_pipeline.out_corrected->anat_headmask.in_file")
-        self.add_link(
-            "anat_skullstrip_pipeline.out_corrected->anat_spatial_norm.moving_image")
+        self.add_link("anat_skullstrip_pipeline.out_mask_synthstrip->"
+                      "fwhmx.mask_file")
+        self.add_link("anat_skullstrip_pipeline.out_mask_synthstrip->"
+                      "anat_spatial_norm.moving_mask")
+        self.add_link("anat_skullstrip_pipeline.out_mask_synthstrip->"
+                      "anat_airmask_pipeline.in_mask")
+        self.add_link("anat_skullstrip_pipeline.out_corrected"
+                      "->harmonize.in_file")
+        self.add_link("anat_skullstrip_pipeline.out_corrected->"
+                      "anat_headmask.in_file")
+        self.add_link("anat_skullstrip_pipeline.out_corrected->"
+                      "anat_spatial_norm.moving_image")
         self.add_link("anat_skullstrip_pipeline.bias_image->anatiqms.in_inu")
         self.add_link("segment.tissue_class_map->anatiqms.segmentation")
         self.add_link("segment.partial_volume_files->list_to_file.file_list")
         self.add_link("segment.partial_volume_files->anatiqms.pvms")
-        self.add_link(
-            "anat_spatial_norm.inverse_composite_transform->anat_mni_tpms_pipeline.inverse_composite_transform")
-        self.add_link(
-            "anat_spatial_norm.inverse_composite_transform->anat_airmask_pipeline.inverse_composite_transform")
-        self.add_link(
-            "anat_spatial_norm.warped_image->mriqc_anat_report.norm_anat")
-        self.add_link(
-            "anat_headmask.outskin_mask_file->anat_airmask_pipeline.head_mask")
+        self.add_link("anat_spatial_norm.inverse_composite_transform"
+                      "->anat_mni_tpms_pipeline.inverse_composite_transform")
+        self.add_link("anat_spatial_norm.inverse_composite_transform->"
+                      "anat_airmask_pipeline.inverse_composite_transform")
+        self.add_link("anat_spatial_norm.warped_image->"
+                      "mriqc_anat_report.norm_anat")
+        self.add_link("anat_headmask.outskin_mask_file->"
+                      "anat_airmask_pipeline.head_mask")
         self.add_link("anat_headmask.outskin_mask_file->anatiqms.headmask")
         self.add_link("anat_airmask_pipeline.out_hat_mask->anatiqms.hatmask")
         self.add_link("anat_airmask_pipeline.out_art_mask->anatiqms.artmask")
@@ -82,7 +92,6 @@ class Anat_mriqc_pipeline(Pipeline):
                               is_optional=False)
 
         # parameters order
-
         self.reorder_traits(("anat_file", "anat_report"))
 
         # default and initial values
@@ -95,7 +104,7 @@ class Anat_mriqc_pipeline(Pipeline):
         self.node_position = {
             "conformimage": (-266.294964300051, 665.2984755165728),
             "inputs": (-760.1707537491396, 306.60591462332025),
-            "anat_skullstrip_pipeline": (-318.30359196600546, 123.01959076904758),
+            "anat_skullstrip_pipeline": (-318.30359196600546, 123.0195907),
             "segment": (-82.8528, -26.389119999999984),
             "anat_spatial_norm": (122.1775299994049, 474.3922141023147),
             "anat_headmask": (239.62046769206347, 245.85271538452383),

--- a/python/mia_processes/pipelines/preprocess/anat_skullstrip_pipeline.py
+++ b/python/mia_processes/pipelines/preprocess/anat_skullstrip_pipeline.py
@@ -6,26 +6,37 @@ class Anat_skullstrip_pipeline(Pipeline):
 
     def pipeline_definition(self):
         # nodes
-        self.add_process("n4_bias_field_correction", "mia_processes.bricks.preprocess.ants.processes.N4BiasFieldCorrection")
+        self.add_process("n4_bias_field_correction",
+                         "mia_processes.bricks.preprocess."
+                         "ants.processes.N4BiasFieldCorrection")
         self.nodes["n4_bias_field_correction"].process.dimension = 3
-        self.add_process("skull_stripping", "mia_processes.bricks.preprocess.afni.processes.SkullStripping")
-        self.add_process("calc", "mia_processes.bricks.preprocess.afni.processes.Calc")
-        self.add_process("binarize", "mia_processes.bricks.preprocess.others.processing.Binarize")
+        self.add_process("skull_stripping",
+                         "mia_processes.bricks.preprocess."
+                         "afni.processes.SkullStripping")
+        self.add_process("calc", "mia_processes.bricks.preprocess"
+                         ".afni.processes.Calc")
+        self.add_process("binarize", "mia_processes.bricks.preprocess."
+                         "others.processing.Binarize")
 
         # links
-        self.export_parameter("calc", "in_file_a", "in_file", is_optional=False)
+        self.export_parameter("calc", "in_file_a",
+                              "in_file", is_optional=False)
         self.add_link("in_file->n4_bias_field_correction.in_file")
-        self.add_link("n4_bias_field_correction.out_file->skull_stripping.in_file")
-        self.export_parameter("n4_bias_field_correction", "out_file", "bias_corrected", is_optional=False)
-        self.export_parameter("n4_bias_field_correction", "bias_image", is_optional=False)
+        self.add_link("n4_bias_field_correction.out_file->"
+                      "skull_stripping.in_file")
+        self.export_parameter("n4_bias_field_correction", "out_file",
+                              "bias_corrected", is_optional=False)
+        self.export_parameter("n4_bias_field_correction",
+                              "bias_image", is_optional=False)
         self.add_link("skull_stripping.out_file->calc.in_file_b")
         self.export_parameter("calc", "out_file", is_optional=False)
         self.add_link("calc.out_file->binarize.in_files")
-        self.export_parameter("binarize", "out_files", "out_mask", is_optional=False)
+        self.export_parameter("binarize", "out_files",
+                              "out_mask", is_optional=False)
 
         # parameters order
-
-        self.reorder_traits(("out_file", "out_mask", "bias_corrected", "bias_image", "in_file"))
+        self.reorder_traits(("out_file", "out_mask", "bias_corrected",
+                             "bias_image", "in_file"))
 
         # default and initial values
         self.nodes["calc"].process.expr = 'a*step(b)'

--- a/python/mia_processes/pipelines/preprocess/anat_skullstrip_synthstrip_pipeline.py
+++ b/python/mia_processes/pipelines/preprocess/anat_skullstrip_synthstrip_pipeline.py
@@ -1,0 +1,78 @@
+from capsul.api import Pipeline
+
+
+class Anat_skullstrip_synthstrip_pipeline(Pipeline):
+
+    def pipeline_definition(self):
+        # nodes
+        self.add_process("pre_n4biasfieldcorrection",
+                         "mia_processes.bricks.preprocess.ants.processes.N4BiasFieldCorrection")
+        self.add_process("pre_clip",
+                         "mia_processes.bricks.preprocess.others.processing.IntensityClip")
+        self.add_process("synthstrip",
+                         "mia_processes.bricks.preprocess.freesurfer.processes.SynthStrip")
+        self.add_process("post_n4biasfieldcorrection",
+                         "mia_processes.bricks.preprocess.ants.processes.N4BiasFieldCorrection")
+        self.add_process("mask",
+                         "mia_processes.bricks.preprocess.others.processing.Mask")
+
+        self.nodes["pre_n4biasfieldcorrection"].process.dimension = 3
+        self.nodes["pre_n4biasfieldcorrection"].process.out_prefix = 'pre_n4c_'
+        self.nodes["pre_n4biasfieldcorrection"].process.rescale_intensities = True
+        self.nodes["post_n4biasfieldcorrection"].process.n_iterations = [50] * 4
+        self.nodes["post_n4biasfieldcorrection"].process.dimension = 3
+        self.nodes["mask"].process.suffix = ''
+        self.nodes["mask"].process.prefix = 'ss_'
+
+        # links
+        self.export_parameter("pre_clip",
+                              "in_file", is_optional=False)
+        # self.add_link("in_file->pre_clip.in_file")
+        self.add_link("pre_n4biasfieldcorrection.out_file->synthstrip.in_file")
+        self.add_link("pre_clip.out_file->pre_n4biasfieldcorrection.in_file")
+        self.add_link("pre_clip.out_file->post_n4biasfieldcorrection.in_file")
+        self.add_link("synthstrip.out_mask->post_n4biasfieldcorrection.weight_image")
+        self.add_link("synthstrip.out_mask->mask.mask_file")
+        self.add_link("post_n4biasfieldcorrection.out_file->mask.in_file")
+        # self.add_link("post_n4biasfieldcorrection.bias_image->applybiascorrection.bias_image")
+        self.export_parameter("synthstrip", "out_mask",
+                              "out_mask_synthstrip", is_optional=True)
+        self.export_parameter("post_n4biasfieldcorrection",
+                              "bias_image", is_optional=True)
+        self.export_parameter("post_n4biasfieldcorrection",
+                              "out_file", "out_corrected", is_optional=True)
+        self.export_parameter("mask",
+                              "out_file", "out_brain", is_optional=True)
+
+        self.reorder_traits(("in_file", "out_mask_synthstrip",
+                             "out_brain", "out_corrected",
+                             "bias_image"))
+
+        # nodes positions
+        self.node_position = {
+            "inputs": (-1151.61875, -639.0),
+            "pre_n4biasfieldcorrection": (-797.0, -502.0),
+            "pre_clip": (-1022.0, -417.0),
+            "synthstrip": (-561.0, -692.0),
+            "post_n4biasfieldcorrection": (-406.0, -434.0),
+            "mask": (-62.0, -528.0),
+            "outputs": (-31.97187500000001, -749.0),
+        }
+
+        # nodes dimensions
+        self.node_dimension = {
+            "intensityclip_1": (168.03125, 215.0),
+            "n4biasfieldcorrection_1": (236.484375, 180.0),
+            "n4biasfieldcorrection_2": (236.484375, 180.0),
+            "synthstrip_1": (176.53125, 110.0),
+            "mask_1": (149.453125, 180.0),
+            "inputs": (99.328125, 110.0),
+            "pre_n4biasfieldcorrection": (236.484375, 180.0),
+            "pre_clip": (168.03125, 215.0),
+            "synthstrip": (179.53125, 110.0),
+            "post_n4biasfieldcorrection": (239.484375, 180.0),
+            "mask": (149.453125, 180.0),
+            "outputs": (165.421875, 215.0),
+        }
+
+        self.do_autoexport_nodes_parameters = False

--- a/python/mia_processes/pipelines/preprocess/anat_skullstrip_synthstrip_pipeline.py
+++ b/python/mia_processes/pipelines/preprocess/anat_skullstrip_synthstrip_pipeline.py
@@ -5,41 +5,45 @@ class Anat_skullstrip_synthstrip_pipeline(Pipeline):
 
     def pipeline_definition(self):
         # nodes
-        self.add_process("pre_n4biasfieldcorrection",
-                         "mia_processes.bricks.preprocess.ants.processes.N4BiasFieldCorrection")
+        self.add_process("pre_n4biasfieldcor",
+                         "mia_processes.bricks.preprocess."
+                         "ants.processes.N4BiasFieldCorrection")
         self.add_process("pre_clip",
-                         "mia_processes.bricks.preprocess.others.processing.IntensityClip")
+                         "mia_processes.bricks.preprocess."
+                         "others.processing.IntensityClip")
         self.add_process("synthstrip",
-                         "mia_processes.bricks.preprocess.freesurfer.processes.SynthStrip")
-        self.add_process("post_n4biasfieldcorrection",
-                         "mia_processes.bricks.preprocess.ants.processes.N4BiasFieldCorrection")
+                         "mia_processes.bricks.preprocess."
+                         "freesurfer.processes.SynthStrip")
+        self.add_process("post_n4biasfieldcor",
+                         "mia_processes.bricks.preprocess."
+                         "ants.processes.N4BiasFieldCorrection")
         self.add_process("mask",
-                         "mia_processes.bricks.preprocess.others.processing.Mask")
+                         "mia_processes.bricks.preprocess."
+                         "others.processing.Mask")
 
-        self.nodes["pre_n4biasfieldcorrection"].process.dimension = 3
-        self.nodes["pre_n4biasfieldcorrection"].process.out_prefix = 'pre_n4c_'
-        self.nodes["pre_n4biasfieldcorrection"].process.rescale_intensities = True
-        self.nodes["post_n4biasfieldcorrection"].process.n_iterations = [50] * 4
-        self.nodes["post_n4biasfieldcorrection"].process.dimension = 3
+        self.nodes["pre_n4biasfieldcor"].process.dimension = 3
+        self.nodes["pre_n4biasfieldcor"].process.out_prefix = 'pre_n4c_'
+        self.nodes["pre_n4biasfieldcor"].process.rescale_intensities = True
+        self.nodes["post_n4biasfieldcor"].process.n_iterations = [50] * 4
+        self.nodes["post_n4biasfieldcor"].process.dimension = 3
         self.nodes["mask"].process.suffix = ''
         self.nodes["mask"].process.prefix = 'ss_'
 
         # links
         self.export_parameter("pre_clip",
                               "in_file", is_optional=False)
-        # self.add_link("in_file->pre_clip.in_file")
-        self.add_link("pre_n4biasfieldcorrection.out_file->synthstrip.in_file")
-        self.add_link("pre_clip.out_file->pre_n4biasfieldcorrection.in_file")
-        self.add_link("pre_clip.out_file->post_n4biasfieldcorrection.in_file")
-        self.add_link("synthstrip.out_mask->post_n4biasfieldcorrection.weight_image")
+        self.add_link("pre_n4biasfieldcor.out_file->synthstrip.in_file")
+        self.add_link("pre_clip.out_file->pre_n4biasfieldcor.in_file")
+        self.add_link("pre_clip.out_file->post_n4biasfieldcor.in_file")
+        self.add_link("synthstrip.out_mask->"
+                      "post_n4biasfieldcor.weight_image")
         self.add_link("synthstrip.out_mask->mask.mask_file")
-        self.add_link("post_n4biasfieldcorrection.out_file->mask.in_file")
-        # self.add_link("post_n4biasfieldcorrection.bias_image->applybiascorrection.bias_image")
+        self.add_link("post_n4biasfieldcor.out_file->mask.in_file")
         self.export_parameter("synthstrip", "out_mask",
                               "out_mask_synthstrip", is_optional=True)
-        self.export_parameter("post_n4biasfieldcorrection",
+        self.export_parameter("post_n4biasfieldcor",
                               "bias_image", is_optional=True)
-        self.export_parameter("post_n4biasfieldcorrection",
+        self.export_parameter("post_n4biasfieldcor",
                               "out_file", "out_corrected", is_optional=True)
         self.export_parameter("mask",
                               "out_file", "out_brain", is_optional=True)
@@ -51,10 +55,10 @@ class Anat_skullstrip_synthstrip_pipeline(Pipeline):
         # nodes positions
         self.node_position = {
             "inputs": (-1151.61875, -639.0),
-            "pre_n4biasfieldcorrection": (-797.0, -502.0),
+            "pre_n4biasfieldcor": (-797.0, -502.0),
             "pre_clip": (-1022.0, -417.0),
             "synthstrip": (-561.0, -692.0),
-            "post_n4biasfieldcorrection": (-406.0, -434.0),
+            "post_n4biasfieldcor": (-406.0, -434.0),
             "mask": (-62.0, -528.0),
             "outputs": (-31.97187500000001, -749.0),
         }
@@ -67,10 +71,10 @@ class Anat_skullstrip_synthstrip_pipeline(Pipeline):
             "synthstrip_1": (176.53125, 110.0),
             "mask_1": (149.453125, 180.0),
             "inputs": (99.328125, 110.0),
-            "pre_n4biasfieldcorrection": (236.484375, 180.0),
+            "pre_n4biasfieldcor": (236.484375, 180.0),
             "pre_clip": (168.03125, 215.0),
             "synthstrip": (179.53125, 110.0),
-            "post_n4biasfieldcorrection": (239.484375, 180.0),
+            "post_n4biasfieldcor": (239.484375, 180.0),
             "mask": (149.453125, 180.0),
             "outputs": (165.421875, 215.0),
         }

--- a/python/mia_processes/pipelines/preprocess/anat_spatial_norm.py
+++ b/python/mia_processes/pipelines/preprocess/anat_spatial_norm.py
@@ -14,7 +14,7 @@ class Anat_spatial_norm(Pipeline):
         self.nodes["registration"].process.convergence_window_size = [15, 5, 3]
         self.nodes["registration"].process.interpolation = 'LanczosWindowedSinc'
         self.nodes["registration"].process.metric = ['Mattes', 'Mattes']
-        self.nodes["registration"].process.metric_weight = [1, 1]
+        self.nodes["registration"].process.metric_weight = [1.0, 1.0]
         self.nodes["registration"].process.number_of_iterations = [[20], [15]]
         self.nodes["registration"].process.radius_or_number_of_bins = [56, 56]
         self.nodes["registration"].process.sampling_percentage = [0.2, 0.1]

--- a/python/mia_processes/pipelines/preprocess/anat_spatial_norm.py
+++ b/python/mia_processes/pipelines/preprocess/anat_spatial_norm.py
@@ -6,11 +6,20 @@ class Anat_spatial_norm(Pipeline):
 
     def pipeline_definition(self):
         # nodes
-        self.add_process("mask_moving_image", "mia_processes.bricks.preprocess.others.processing.Mask")
-        self.add_process("mask_fixed_image", "mia_processes.bricks.preprocess.others.processing.Mask")
-        self.add_process("affine_initializer", "mia_processes.bricks.preprocess.ants.processes.AffineInitializer")
-        self.add_process("registration", "mia_processes.bricks.preprocess.ants.processes.Registration")
-        self.nodes["registration"].process.convergence_threshold = [1e-07, 1e-08]
+        self.add_process("mask_moving_image",
+                         "mia_processes.bricks.preprocess."
+                         "others.processing.Mask")
+        self.add_process("mask_fixed_image",
+                         "mia_processes.bricks.preprocess."
+                         "others.processing.Mask")
+        self.add_process("affine_initializer",
+                         "mia_processes.bricks.preprocess."
+                         "ants.processes.AffineInitializer")
+        self.add_process("registration",
+                         "mia_processes.bricks.preprocess."
+                         "ants.processes.Registration")
+        self.nodes["registration"].process.convergence_threshold = [1e-07,
+                                                                    1e-08]
         self.nodes["registration"].process.convergence_window_size = [15, 5, 3]
         self.nodes["registration"].process.interpolation = 'LanczosWindowedSinc'
         self.nodes["registration"].process.metric = ['Mattes', 'Mattes']
@@ -18,39 +27,56 @@ class Anat_spatial_norm(Pipeline):
         self.nodes["registration"].process.number_of_iterations = [[20], [15]]
         self.nodes["registration"].process.radius_or_number_of_bins = [56, 56]
         self.nodes["registration"].process.sampling_percentage = [0.2, 0.1]
-        self.nodes["registration"].process.sampling_strategy = ['Random', 'Random']
+        self.nodes["registration"].process.sampling_strategy = ['Random',
+                                                                'Random']
         self.nodes["registration"].process.shrink_factors = [[2], [1]]
         self.nodes["registration"].process.smoothing_sigmas = [[4.0], [2.0]]
-        self.nodes["registration"].process.transform_parameters = [(1.0,), (1.0,)]
+        self.nodes["registration"].process.transform_parameters = [(1.0,),
+                                                                   (1.0,)]
         self.nodes["registration"].process.transforms = ['Rigid', 'Affine']
-        self.nodes["registration"].process.use_histogram_matching = [False, True]
-        self.add_process("template_mask", "mia_processes.bricks.preprocess.others.processing.Template")
+        self.nodes["registration"].process.use_histogram_matching = [False,
+                                                                     True]
+        self.add_process("template_mask",
+                         "mia_processes.bricks.preprocess."
+                         "others.processing.Template")
         self.nodes["template_mask"].process.suffix = 'mask'
         self.nodes["template_mask"].process.desc = 'brain'
         self.nodes["template_mask"].process.in_template = 'MNI152NLin2009cAsym'
         self.nodes["template_mask"].process.resolution = 2
-        self.add_process("template", "mia_processes.bricks.preprocess.others.processing.Template")
+        self.add_process("template",
+                         "mia_processes.bricks.preprocess."
+                         "others.processing.Template")
         self.nodes["template"].process.suffix = 'T1w'
         self.nodes["template"].process.in_template = 'MNI152NLin2009cAsym'
         self.nodes["template"].process.resolution = 2
 
         # links
-        self.export_parameter("mask_moving_image", "in_file", "moving_image", is_optional=False)
-        self.export_parameter("mask_moving_image", "mask_file", "moving_mask", is_optional=False)
-        self.add_link("mask_moving_image.out_file->affine_initializer.moving_image")
+        self.export_parameter("mask_moving_image", "in_file",
+                              "moving_image", is_optional=False)
+        self.export_parameter("mask_moving_image", "mask_file",
+                              "moving_mask", is_optional=False)
+        self.add_link("mask_moving_image.out_file->"
+                      "affine_initializer.moving_image")
         self.add_link("mask_moving_image.out_file->registration.moving_image")
-        self.add_link("mask_fixed_image.out_file->affine_initializer.fixed_image")
+        self.add_link("mask_fixed_image.out_file->"
+                      "affine_initializer.fixed_image")
         self.add_link("mask_fixed_image.out_file->registration.fixed_image")
-        self.add_link("affine_initializer.out_file->registration.initial_moving_transform")
-        self.export_parameter("registration", "composite_transform", is_optional=True)
-        self.export_parameter("registration", "inverse_composite_transform", is_optional=False)
-        self.export_parameter("registration", "warped_image", is_optional=False)
+        self.add_link("affine_initializer.out_file->"
+                      "registration.initial_moving_transform")
+        self.export_parameter("registration", "composite_transform",
+                              is_optional=True)
+        self.export_parameter("registration", "inverse_composite_transform",
+                              is_optional=False)
+        self.export_parameter("registration", "warped_image",
+                              is_optional=False)
         self.add_link("template_mask.template->mask_fixed_image.mask_file")
         self.add_link("template.template->mask_fixed_image.in_file")
 
         # parameters order
-
-        self.reorder_traits(("moving_image", "moving_mask", "composite_transform", "inverse_composite_transform", "warped_image"))
+        self.reorder_traits(("moving_image", "moving_mask",
+                             "composite_transform",
+                             "inverse_composite_transform",
+                             "warped_image"))
 
         # default and initial values
         self.template = 'MNI152NLin2009cAsym'

--- a/python/mia_processes/pipelines/preprocess/anat_spatial_norm.py
+++ b/python/mia_processes/pipelines/preprocess/anat_spatial_norm.py
@@ -10,19 +10,20 @@ class Anat_spatial_norm(Pipeline):
         self.add_process("mask_fixed_image", "mia_processes.bricks.preprocess.others.processing.Mask")
         self.add_process("affine_initializer", "mia_processes.bricks.preprocess.ants.processes.AffineInitializer")
         self.add_process("registration", "mia_processes.bricks.preprocess.ants.processes.Registration")
-        self.nodes["registration"].process.convergence_threshold = [1e-06, 1e-06, 1e-06]
-        self.nodes["registration"].process.convergence_window_size = [20, 20, 10]
+        self.nodes["registration"].process.convergence_threshold = [1e-07, 1e-08]
+        self.nodes["registration"].process.convergence_window_size = [15, 5, 3]
         self.nodes["registration"].process.interpolation = 'LanczosWindowedSinc'
-        self.nodes["registration"].process.metric = ['Mattes', 'Mattes', 'Mattes']
-        self.nodes["registration"].process.metric_weight = [1, 1, 1]
-        self.nodes["registration"].process.number_of_iterations = [[1000], [500, 250, 100], [50, 20]]
-        self.nodes["registration"].process.radius_or_number_of_bins = [32, 32, 56]
-        self.nodes["registration"].process.sampling_percentage = [0.15, 0.15, 0.25]
-        self.nodes["registration"].process.sampling_strategy = ['Random', 'Regular', 'Regular']
-        self.nodes["registration"].process.shrink_factors = [[4], [4, 2, 1], [2, 1]]
-        self.nodes["registration"].process.smoothing_sigmas = [[4.0], [4.0, 2.0, 0.0], [1.0, 0.0]]
-        self.nodes["registration"].process.transform_parameters = [(0.01,), (0.08,), (0.1, 3.0, 0.0)]
-        self.nodes["registration"].process.transforms = ['Rigid', 'Affine', 'SyN']
+        self.nodes["registration"].process.metric = ['Mattes', 'Mattes']
+        self.nodes["registration"].process.metric_weight = [1, 1]
+        self.nodes["registration"].process.number_of_iterations = [[20], [15]]
+        self.nodes["registration"].process.radius_or_number_of_bins = [56, 56]
+        self.nodes["registration"].process.sampling_percentage = [0.2, 0.1]
+        self.nodes["registration"].process.sampling_strategy = ['Random', 'Random']
+        self.nodes["registration"].process.shrink_factors = [[2], [1]]
+        self.nodes["registration"].process.smoothing_sigmas = [[4.0], [2.0]]
+        self.nodes["registration"].process.transform_parameters = [(1.0,), (1.0,)]
+        self.nodes["registration"].process.transforms = ['Rigid', 'Affine']
+        self.nodes["registration"].process.use_histogram_matching = [False, True]
         self.add_process("template_mask", "mia_processes.bricks.preprocess.others.processing.Template")
         self.nodes["template_mask"].process.suffix = 'mask'
         self.nodes["template_mask"].process.desc = 'brain'

--- a/python/mia_processes/pipelines/preprocess/bold_hmc_pipeline.py
+++ b/python/mia_processes/pipelines/preprocess/bold_hmc_pipeline.py
@@ -6,34 +6,28 @@ class Bold_hmc_pipeline(Pipeline):
 
     def pipeline_definition(self):
         # nodes
-        self.add_process("droptrs", "mia_processes.bricks.preprocess.afni.processes.DropTRs")
-        self.add_process("tshift", "mia_processes.bricks.preprocess.afni.processes.TShift")
         self.add_process("despike", "mia_processes.bricks.preprocess.afni.processes.Despike")
         self.add_process("deoblique", "mia_processes.bricks.preprocess.afni.processes.Deoblique")
         self.add_process("volreg", "mia_processes.bricks.preprocess.afni.processes.Volreg")
         self.nodes["volreg"].process.twopass = True
+        self.nodes["despike"].process.despike = False
+        self.nodes["deoblique"].process.deoblique = False
 
         # links
-        self.export_parameter("droptrs", "in_file", is_optional=False)
-        self.export_parameter("droptrs", "start_idx", is_optional=True)
-        self.export_parameter("droptrs", "stop_idx", is_optional=True)
+        self.export_parameter("despike", "in_file", is_optional=False)
         self.export_parameter("despike", "despike", is_optional=True)
         self.export_parameter("deoblique", "deoblique", is_optional=True)
-        self.add_link("droptrs.out_file->tshift.in_file")
-        self.add_link("tshift.out_file->despike.in_file")
         self.add_link("despike.out_file->deoblique.in_file")
         self.add_link("deoblique.out_file->volreg.in_file")
         self.export_parameter("volreg", "out_file", is_optional=False)
         self.export_parameter("volreg", "oned_file", is_optional=False)
 
         # parameters order
-
-        self.reorder_traits(("in_file", "start_idx", "stop_idx", "despike", "deoblique", "out_file", "oned_file"))
+        self.reorder_traits(("in_file", "despike", "deoblique", "out_file",
+                             "oned_file"))
 
         # nodes positions
         self.node_position = {
-            "droptrs": (-364.0, -61.0),
-            "tshift": (-189.79999999999998, 113.80000000000004),
             "despike": (21.799999999999983, 294.59999999999997),
             "deoblique": (186.20000000000005, 439.9999999999999),
             "volreg": (353.6, 514.3999999999999),
@@ -43,8 +37,6 @@ class Bold_hmc_pipeline(Pipeline):
 
         # nodes dimensions
         self.node_dimension = {
-            "droptrs": (165.65625, 215.0),
-            "tshift": (207.046875, 215.0),
             "despike": (165.65625, 180.0),
             "deoblique": (151.03125, 110.0),
             "volreg": (176.625, 250.0),

--- a/python/mia_processes/pipelines/preprocess/bold_hmc_pipeline.py
+++ b/python/mia_processes/pipelines/preprocess/bold_hmc_pipeline.py
@@ -6,9 +6,15 @@ class Bold_hmc_pipeline(Pipeline):
 
     def pipeline_definition(self):
         # nodes
-        self.add_process("despike", "mia_processes.bricks.preprocess.afni.processes.Despike")
-        self.add_process("deoblique", "mia_processes.bricks.preprocess.afni.processes.Deoblique")
-        self.add_process("volreg", "mia_processes.bricks.preprocess.afni.processes.Volreg")
+        self.add_process("despike",
+                         "mia_processes.bricks.preprocess."
+                         "afni.processes.Despike")
+        self.add_process("deoblique",
+                         "mia_processes.bricks.preprocess."
+                         "afni.processes.Deoblique")
+        self.add_process("volreg",
+                         "mia_processes.bricks.preprocess."
+                         "afni.processes.Volreg")
         self.nodes["volreg"].process.twopass = True
         self.nodes["despike"].process.despike = False
         self.nodes["deoblique"].process.deoblique = False

--- a/python/mia_processes/pipelines/preprocess/bold_mni_align.py
+++ b/python/mia_processes/pipelines/preprocess/bold_mni_align.py
@@ -6,75 +6,136 @@ class Bold_mni_align(Pipeline):
 
     def pipeline_definition(self):
         # nodes
-        self.add_process("affineinitializer", "mia_processes.bricks.preprocess.ants.processes.AffineInitializer")
-        self.add_process("registration", "mia_processes.bricks.preprocess.ants.processes.Registration")
+        self.add_process("affineinitializer",
+                         "mia_processes.bricks.preprocess."
+                         "ants.processes.AffineInitializer")
+        self.add_process("registration",
+                         "mia_processes.bricks.preprocess."
+                         "ants.processes.Registration")
         self.nodes["registration"].process.fixed_image_masks = traits.Undefined
-        self.nodes["registration"].process.convergence_threshold = [1e-06, 1e-06, 1e-06]
-        self.nodes["registration"].process.convergence_window_size = [20, 20, 10]
+        self.nodes["registration"].process.convergence_threshold = [1e-06,
+                                                                    1e-06,
+                                                                    1e-06]
+        self.nodes["registration"].process.convergence_window_size = [20,
+                                                                      20,
+                                                                      10]
         self.nodes["registration"].process.interpolation = 'LanczosWindowedSinc'
         self.nodes["registration"].process.metric = ['Mattes', 'Mattes', 'CC']
         self.nodes["registration"].process.metric_weight = [1, 1, 1]
-        self.nodes["registration"].process.number_of_iterations = [[10000, 1000, 100], [500, 250, 100], [100, 30, 20]]
-        self.nodes["registration"].process.radius_or_number_of_bins = [56, 56, 4]
-        self.nodes["registration"].process.sampling_percentage = [0.25, 0.25, 1.0]
-        self.nodes["registration"].process.sampling_strategy = ['Regular', 'Regular', 'None']
-        self.nodes["registration"].process.shrink_factors = [[4, 2, 1], [8, 4, 2], [8, 4, 2]]
-        self.nodes["registration"].process.smoothing_sigmas = [[4.0, 2.0, 1.0], [4.0, 2.0, 0.0], [3.0, 2.0, 1.0]]
-        self.nodes["registration"].process.transform_parameters = [(0.05,), (0.08,), (0.1, 3.0, 0.0)]
-        self.nodes["registration"].process.transforms = ['Rigid', 'Affine', 'SyN']
-        self.add_process("n4biasfieldcorrection", "mia_processes.bricks.preprocess.ants.processes.N4BiasFieldCorrection")
+        self.nodes["registration"].process.number_of_iterations = [
+            [10000, 1000, 100], [500, 250, 100], [100, 30, 20]]
+        self.nodes["registration"].process.radius_or_number_of_bins = [56,
+                                                                       56,
+                                                                       4]
+        self.nodes["registration"].process.sampling_percentage = [0.25,
+                                                                  0.25,
+                                                                  1.0]
+        self.nodes["registration"].process.sampling_strategy = ['Regular',
+                                                                'Regular',
+                                                                'None']
+        self.nodes["registration"].process.shrink_factors = [[4, 2, 1],
+                                                             [8, 4, 2],
+                                                             [8, 4, 2]]
+        self.nodes["registration"].process.smoothing_sigmas = [[4.0, 2.0, 1.0],
+                                                               [4.0, 2.0, 0.0],
+                                                               [3.0, 2.0, 1.0]]
+        self.nodes["registration"].process.transform_parameters = [(0.05,),
+                                                                   (0.08,),
+                                                                   (0.1,
+                                                                    3.0,
+                                                                       0.0)]
+        self.nodes["registration"].process.transforms = ['Rigid',
+                                                         'Affine',
+                                                         'SyN']
+        self.add_process("n4biasfieldcorrection",
+                         "mia_processes.bricks.preprocess."
+                         "ants.processes.N4BiasFieldCorrection")
         self.nodes["n4biasfieldcorrection"].process.dimension = 3
-        self.add_process("applytransforms", "mia_processes.bricks.preprocess.ants.processes.ApplyTransforms")
+        self.add_process("applytransforms",
+                         "mia_processes.bricks.preprocess."
+                         "ants.processes.ApplyTransforms")
         self.nodes["applytransforms"].process.interpolation = 'MultiLabel'
-        self.add_process("template", "mia_processes.bricks.preprocess.others.processing.Template")
+        self.add_process("template",
+                         "mia_processes.bricks.preprocess."
+                         "others.processing.Template")
         self.nodes["template"].process.suffix = 'boldref'
         self.nodes["template"].process.desc = 'fMRIPrep'
-        self.add_process("template_mask", "mia_processes.bricks.preprocess.others.processing.Template")
+        self.add_process("template_mask",
+                         "mia_processes.bricks.preprocess."
+                         "others.processing.Template")
         self.nodes["template_mask"].process.suffix = 'mask'
         self.nodes["template_mask"].process.desc = 'brain'
-        self.add_process("seg_template", "mia_processes.bricks.preprocess.others.processing.Template")
+        self.add_process("seg_template",
+                         "mia_processes.bricks.preprocess."
+                         "others.processing.Template")
         self.nodes["seg_template"].process.suffix = 'dseg'
         self.nodes["seg_template"].process.desc = 'carpet'
 
         # links
-        self.export_parameter("registration", "moving_image_masks", "epi_mask", is_optional=True)
-        self.export_parameter("n4biasfieldcorrection", "in_file", "epi_mean", is_optional=False)
+        self.export_parameter("registration", "moving_image_masks", "epi_mask",
+                              is_optional=True)
+        self.export_parameter("n4biasfieldcorrection", "in_file", "epi_mean",
+                              is_optional=False)
         self.add_link("epi_mean->applytransforms.reference_image")
-        self.export_parameter("template", "in_template", "template", is_optional=True)
+        self.export_parameter("template", "in_template", "template",
+                              is_optional=True)
         self.add_link("template->template_mask.in_template")
         self.add_link("template->seg_template.in_template")
-        self.export_parameter("template_mask", "resolution", "template_res", is_optional=True)
+        self.export_parameter("template_mask", "resolution", "template_res",
+                              is_optional=True)
         self.add_link("template_res->template.resolution")
-        self.export_parameter("seg_template", "resolution", "seg_template_res", is_optional=True)
-        self.export_parameter("registration", "transforms", "reg_transforms", is_optional=True)
-        self.export_parameter("registration", "transform_parameters", "reg_transform_parameters", is_optional=True)
-        self.export_parameter("registration", "metric", "reg_metric", is_optional=True)
-        self.export_parameter("registration", "metric_weight", "reg_metric_weight", is_optional=True)
-        self.export_parameter("registration", "shrink_factors", "reg_shrink_factors", is_optional=True)
-        self.export_parameter("registration", "smoothing_sigmas", "reg_smoothing_sigmas", is_optional=True)
-        self.export_parameter("registration", "number_of_iterations", "reg_number_of_iterations", is_optional=True)
-        self.export_parameter("registration", "radius_or_number_of_bins", "reg_radius_or_number_of_bins", is_optional=True)
-        self.export_parameter("registration", "convergence_threshold", "reg_convergence_threshold", is_optional=True)
-        self.export_parameter("registration", "convergence_window_size", "reg_convergence_window_size", is_optional=True)
-        self.export_parameter("registration", "sampling_percentage", "reg_sampling_percentage", is_optional=True)
-        self.export_parameter("registration", "sampling_strategy", "reg_sampling_strategy", is_optional=True)
-        self.export_parameter("registration", "interpolation", "reg_interpolation", is_optional=True)
-        self.add_link("affineinitializer.out_file->registration.initial_moving_transform")
-        self.export_parameter("registration", "composite_transform", is_optional=True)
-        self.export_parameter("registration", "inverse_composite_transform", is_optional=True)
-        self.add_link("registration.inverse_composite_transform->applytransforms.transforms")
-        self.export_parameter("registration", "warped_image", "epi_mni", is_optional=False)
-        self.add_link("n4biasfieldcorrection.out_file->registration.moving_image")
-        self.add_link("n4biasfieldcorrection.out_file->affineinitializer.moving_image")
-        self.export_parameter("n4biasfieldcorrection", "bias_image", is_optional=True)
-        self.export_parameter("applytransforms", "output_image", "epi_parc", is_optional=False)
+        self.export_parameter("seg_template", "resolution", "seg_template_res",
+                              is_optional=True)
+        self.export_parameter("registration", "transforms",
+                              "reg_transforms", is_optional=True)
+        self.export_parameter("registration", "transform_parameters",
+                              "reg_transform_parameters", is_optional=True)
+        self.export_parameter("registration", "metric", "reg_metric",
+                              is_optional=True)
+        self.export_parameter("registration", "metric_weight",
+                              "reg_metric_weight", is_optional=True)
+        self.export_parameter("registration", "shrink_factors",
+                              "reg_shrink_factors", is_optional=True)
+        self.export_parameter("registration", "smoothing_sigmas",
+                              "reg_smoothing_sigmas", is_optional=True)
+        self.export_parameter("registration", "number_of_iterations",
+                              "reg_number_of_iterations", is_optional=True)
+        self.export_parameter("registration", "radius_or_number_of_bins",
+                              "reg_radius_or_number_of_bins", is_optional=True)
+        self.export_parameter("registration", "convergence_threshold",
+                              "reg_convergence_threshold", is_optional=True)
+        self.export_parameter("registration", "convergence_window_size",
+                              "reg_convergence_window_size", is_optional=True)
+        self.export_parameter("registration", "sampling_percentage",
+                              "reg_sampling_percentage", is_optional=True)
+        self.export_parameter("registration", "sampling_strategy",
+                              "reg_sampling_strategy", is_optional=True)
+        self.export_parameter("registration", "interpolation",
+                              "reg_interpolation", is_optional=True)
+        self.add_link("affineinitializer.out_file->"
+                      "registration.initial_moving_transform")
+        self.export_parameter("registration", "composite_transform",
+                              is_optional=True)
+        self.export_parameter("registration", "inverse_composite_transform",
+                              is_optional=True)
+        self.add_link("registration.inverse_composite_transform->"
+                      "applytransforms.transforms")
+        self.export_parameter("registration", "warped_image", "epi_mni",
+                              is_optional=False)
+        self.add_link("n4biasfieldcorrection.out_file->"
+                      "registration.moving_image")
+        self.add_link("n4biasfieldcorrection.out_file->"
+                      "affineinitializer.moving_image")
+        self.export_parameter("n4biasfieldcorrection", "bias_image",
+                              is_optional=True)
+        self.export_parameter("applytransforms", "output_image", "epi_parc",
+                              is_optional=False)
         self.add_link("template.template->registration.fixed_image")
         self.add_link("template.template->affineinitializer.fixed_image")
         self.add_link("template_mask.template->registration.fixed_image_masks")
         self.add_link("seg_template.template->applytransforms.input_image")
 
         # parameters order
-
         self.reorder_traits(("epi_mask", "epi_mean", "epi_parc", "template",
                              "template_res", "epi_mni", "composite_transform",
                              "inverse_composite_transform",

--- a/python/mia_processes/pipelines/preprocess/bold_mriqc_pipeline.py
+++ b/python/mia_processes/pipelines/preprocess/bold_mriqc_pipeline.py
@@ -36,13 +36,9 @@ class Bold_mriqc_pipeline(Pipeline):
         self.add_process("automask",
                          "mia_processes.bricks.preprocess.afni.processes."
                          "Automask")
-        self.add_process("bold_hmc_pipeline",
-                         "mia_processes.pipelines.preprocess.bold_hmc_pipeline."
-                         "Bold_hmc_pipeline")
-        self.nodes["bold_hmc_pipeline"].process.nodes_activation = {
-            'despike': False,
-            'deoblique': False,
-            'volreg': True}
+        self.add_process("volreg",
+                         "mia_processes.bricks.preprocess.afni.processes.Volreg")
+        self.nodes["volreg"].process.twopass = True
         self.add_process("bold_mni_align",
                          "mia_processes.pipelines.preprocess.bold_mni_align."
                          "Bold_mni_align")
@@ -65,10 +61,6 @@ class Bold_mriqc_pipeline(Pipeline):
                          "MRIQC_func_report")
 
         # links
-        self.export_parameter("bold_hmc_pipeline", "despike",
-                              pipeline_parameter="hmc_despike")
-        self.export_parameter("bold_hmc_pipeline", "deoblique",
-                              pipeline_parameter="hmc_deoblique")
         self.export_parameter("sanitize", "in_file",
                               pipeline_parameter="func_file",
                               is_optional=False)
@@ -81,17 +73,17 @@ class Bold_mriqc_pipeline(Pipeline):
         self.add_link("nonsteadystatedetector.n_volumes_to_discard->"
                       "bold_iqms_pipeline.dummy_TRs")
         self.add_link("sanitize.out_file->bold_iqms_pipeline.ras_epi")
-        self.add_link("sanitize.out_file->bold_hmc_pipeline.in_file")
+        self.add_link("sanitize.out_file->volreg.in_file")
         self.add_link("tsnr.out_tsnr_file->bold_iqms_pipeline.epi_tsnr")
         self.add_link("mean.out_file->bold_mni_align.epi_mean")
         self.add_link("mean.out_file->automask.in_file")
         self.add_link("mean.out_file->bold_iqms_pipeline.epi_mean")
         self.add_link("automask.out_file->bold_mni_align.epi_mask")
         self.add_link("automask.out_file->bold_iqms_pipeline.brainmask")
-        self.add_link("bold_hmc_pipeline.out_file->tsnr.in_file")
-        self.add_link("bold_hmc_pipeline.out_file->mean.in_file")
-        self.add_link("bold_hmc_pipeline.out_file->bold_iqms_pipeline.hmc_epi")
-        self.add_link("bold_hmc_pipeline.oned_file->"
+        self.add_link("volreg.out_file->tsnr.in_file")
+        self.add_link("volreg.out_file->mean.in_file")
+        self.add_link("volreg.out_file->bold_iqms_pipeline.hmc_epi")
+        self.add_link("volreg.oned_file->"
                       "bold_iqms_pipeline.hmc_motion")
         self.add_link("bold_mni_align.epi_parc->bold_iqms_pipeline.epi_parc")
         self.add_link("bold_mni_align.epi_mni->mriqc_func_report.norm_func")
@@ -102,10 +94,7 @@ class Bold_mriqc_pipeline(Pipeline):
                               is_optional=True)
 
         # parameters order
-
         self.reorder_traits(("func_file", "carpet_seg", "func_report"))
-
-        # default and initial values
 
         # nodes positions
         self.node_position = {
@@ -115,7 +104,7 @@ class Bold_mriqc_pipeline(Pipeline):
             "tsnr": (-127.7391993962027, 60.050718720000134),
             "mean": (-173.11641600000007, -181.6966963199999),
             "automask": (144.1320191999998, -189.81009407999983),
-            "bold_hmc_pipeline": (-527.8792115199997, -149.2405196799998),
+            "volreg": (-527.8792115199997, -149.2405196799998),
             "bold_mni_align": (283.31445431594545, 116.08725895240536),
             "inputs": (-890.4021152762024, 569.7810895696218),
             "outputs": (1530.1459691893501, 147.22476292910784),
@@ -130,7 +119,7 @@ class Bold_mriqc_pipeline(Pipeline):
             "tsnr": (194.03125, 215.0),
             "mean": (146.0, 145.0),
             "automask": (146.0, 145.0),
-            "bold_hmc_pipeline": (154.453125, 215.0),
+            "volreg": (154.453125, 215.0),
             "bold_mni_align": (377.796875, 670.0),
             "inputs": (243.9375, 1265.0),
             "outputs": (203.16492003946317, 355.0),

--- a/python/mia_processes/pipelines/preprocess/bold_mriqc_pipeline.py
+++ b/python/mia_processes/pipelines/preprocess/bold_mriqc_pipeline.py
@@ -10,7 +10,7 @@ class Bold_mriqc_pipeline(Pipeline):
         # nodes
         self.add_process("bold_iqms_pipeline",
                          "mia_processes.pipelines.reports.bold_iqms_pipeline."
-                             "Bold_iqms_pipeline")
+                         "Bold_iqms_pipeline")
         self.nodes["bold_iqms_pipeline"].process.nodes_activation = {
             'outliercount': True,
             'boldiqms': True,
@@ -23,36 +23,34 @@ class Bold_mriqc_pipeline(Pipeline):
             'qualityindex': True}
         self.add_process("nonsteadystatedetector",
                          "mia_processes.bricks.preprocess.others.processing."
-                             "NonSteadyStateDetector")
+                         "NonSteadyStateDetector")
         self.add_process("sanitize",
                          "mia_processes.bricks.preprocess.others.processing."
-                             "Sanitize")
+                         "Sanitize")
         self.add_process("tsnr",
                          "mia_processes.bricks.preprocess.others.processing."
-                             "TSNR")
+                         "TSNR")
         self.add_process("mean",
                          "mia_processes.bricks.preprocess.afni.processes."
-                             "Mean")
+                         "Mean")
         self.add_process("automask",
                          "mia_processes.bricks.preprocess.afni.processes."
-                             "Automask")
+                         "Automask")
         self.add_process("bold_hmc_pipeline",
                          "mia_processes.pipelines.preprocess.bold_hmc_pipeline."
-                             "Bold_hmc_pipeline")
+                         "Bold_hmc_pipeline")
         self.nodes["bold_hmc_pipeline"].process.nodes_activation = {
-            'droptrs': True,
-            'tshift': True,
-            'despike': True,
-            'deoblique': True,
+            'despike': False,
+            'deoblique': False,
             'volreg': True}
         self.add_process("bold_mni_align",
                          "mia_processes.pipelines.preprocess.bold_mni_align."
-                             "Bold_mni_align")
+                         "Bold_mni_align")
         self.nodes["bold_mni_align"].set_plug_value("epi_mask",
                                                     traits.Undefined)
         self.nodes["bold_mni_align"].process.nodes[
-                            "registration"].set_plug_value("moving_image_masks",
-                                                           traits.Undefined)
+            "registration"].set_plug_value("moving_image_masks",
+                                           traits.Undefined)
         self.nodes["bold_mni_align"].process.nodes_activation = {
             'affineinitializer': True,
             'registration': True,
@@ -64,19 +62,24 @@ class Bold_mriqc_pipeline(Pipeline):
         self.nodes["bold_mni_align"].process.epi_mask = traits.Undefined
         self.add_process("mriqc_func_report",
                          "mia_processes.bricks.reports.reporting."
-                             "MRIQC_func_report")
+                         "MRIQC_func_report")
 
         # links
+        self.export_parameter("bold_hmc_pipeline", "despike",
+                              pipeline_parameter="hmc_despike")
+        self.export_parameter("bold_hmc_pipeline", "deoblique",
+                              pipeline_parameter="hmc_deoblique")
         self.export_parameter("sanitize", "in_file",
-                              pipeline_parameter="func_file", is_optional=False)
+                              pipeline_parameter="func_file",
+                              is_optional=False)
         self.add_link("func_file->nonsteadystatedetector.in_file")
         self.add_link("func_file->mriqc_func_report.func")
         self.add_link("bold_iqms_pipeline.BoldQC_out_file->"
-                          "mriqc_func_report.IQMs_file")
+                      "mriqc_func_report.IQMs_file")
         self.add_link("nonsteadystatedetector.n_volumes_to_discard->"
-                          "sanitize.n_volumes_to_discard")
+                      "sanitize.n_volumes_to_discard")
         self.add_link("nonsteadystatedetector.n_volumes_to_discard->"
-                          "bold_iqms_pipeline.dummy_TRs")
+                      "bold_iqms_pipeline.dummy_TRs")
         self.add_link("sanitize.out_file->bold_iqms_pipeline.ras_epi")
         self.add_link("sanitize.out_file->bold_hmc_pipeline.in_file")
         self.add_link("tsnr.out_tsnr_file->bold_iqms_pipeline.epi_tsnr")
@@ -89,7 +92,7 @@ class Bold_mriqc_pipeline(Pipeline):
         self.add_link("bold_hmc_pipeline.out_file->mean.in_file")
         self.add_link("bold_hmc_pipeline.out_file->bold_iqms_pipeline.hmc_epi")
         self.add_link("bold_hmc_pipeline.oned_file->"
-                          "bold_iqms_pipeline.hmc_motion")
+                      "bold_iqms_pipeline.hmc_motion")
         self.add_link("bold_mni_align.epi_parc->bold_iqms_pipeline.epi_parc")
         self.add_link("bold_mni_align.epi_mni->mriqc_func_report.norm_func")
         self.export_parameter("mriqc_func_report", "report",

--- a/python/mia_processes/pipelines/preprocess/bold_mriqc_pipeline.py
+++ b/python/mia_processes/pipelines/preprocess/bold_mriqc_pipeline.py
@@ -37,7 +37,8 @@ class Bold_mriqc_pipeline(Pipeline):
                          "mia_processes.bricks.preprocess.afni.processes."
                          "Automask")
         self.add_process("volreg",
-                         "mia_processes.bricks.preprocess.afni.processes.Volreg")
+                         "mia_processes.bricks.preprocess.afni.processes."
+                         "Volreg")
         self.nodes["volreg"].process.twopass = True
         self.add_process("bold_mni_align",
                          "mia_processes.pipelines.preprocess.bold_mni_align."

--- a/python/mia_processes/utils/report.py
+++ b/python/mia_processes/utils/report.py
@@ -167,7 +167,7 @@ class Report():
                   "MRIQC CALCULATION DATE", "NAME OF THE INPUT DATA",
                   "PATIENT REFERENCE", "PATIENT SEX", "PATIENT AGE",
                   "SOFTWARES", ]
-        headers.extend([" "] *  5)
+        headers.extend([" "] * 5)
 
         cover_data = [[0, 0]]
 
@@ -205,10 +205,10 @@ class Report():
                                         "&nbsp&nbsp&nbsp :</b></para>",
                                       self.styles["BodyText"]),
                             Paragraph("<para align=justify><font size = 7>" +
-                                      info +
-                                      "</font></para>" if
-                                      header == "NAME OF THE INPUT DATA" else
-                                      "<para align=justify>" + info + "</para>",
+                                        info + "</font></para>" if
+                                        header == "NAME OF THE INPUT DATA" else
+                                        "<para align=justify>" + str(info) +
+                                        "</para>",
                                       self.styles["Normal"])]
 
                 cover_data.append(temp)
@@ -1079,14 +1079,15 @@ class Report():
         # Currently, we make and save (in derived_data) the qi2 graph, but we
         # don't include it in the report because the result with the test data
         # looks strange.
-        _ = plot_qi2(np.asarray(self.iqms_data['histogram_qi2_x_grid']),
-                     np.asarray(self.iqms_data['histogram_qi2_ref_pdf']),
-                     np.asarray(self.iqms_data['histogram_qi2_fit_pdf']),
-                     np.asarray(self.iqms_data['histogram_qi2_ref_data']),
-                     int(self.iqms_data['histogram_qi2_cutoff_idx']),
-                     out_file=os.path.join(
-                         os.path.split(os.path.split(self.anat)[0])[0],
-                         'derived_data', 'qi2_plot.svg'))
+        # FIXME: Commented since 27/02/2027 because KeyError: 'histogram_qi2_x_grid'
+        #_ = plot_qi2(np.asarray(self.iqms_data['histogram_qi2_x_grid']),
+        #             np.asarray(self.iqms_data['histogram_qi2_ref_pdf']),
+        #             np.asarray(self.iqms_data['histogram_qi2_fit_pdf']),
+        #             np.asarray(self.iqms_data['histogram_qi2_ref_data']),
+        #             int(self.iqms_data['histogram_qi2_cutoff_idx']),
+        #             out_file=os.path.join(
+        #                 os.path.split(os.path.split(self.anat)[0])[0],
+        #                 'derived_data', 'qi2_plot.svg'))
 
         self.page.build(self.report, canvasmaker=PageNumCanvas)
         tmpdir.cleanup()

--- a/python/mia_processes/utils/report.py
+++ b/python/mia_processes/utils/report.py
@@ -349,7 +349,7 @@ class Report():
         # aor
         self.report.append(self.get_iqms_data('aor'))
         self.report.append(Spacer(0 * mm, 1 * mm))
-        # aor
+        # aqi
         self.report.append(self.get_iqms_data('aqi'))
         self.report.append(Spacer(0 * mm, 2.5 * mm))
         # gsr_x
@@ -369,7 +369,7 @@ class Report():
         self.report.append(Spacer(0 * mm, 2.5 * mm))
         # dummyTRs
         self.report.append(self.get_iqms_data('dummyTRs'))
-        self.report.append(Spacer(0 * mm, 90 * mm))
+        self.report.append(Spacer(0 * mm, 82 * mm))
         # Footnote
         line = ReportLine(500)
         line.hAlign = 'CENTER'

--- a/python/mia_processes/utils/report.py
+++ b/python/mia_processes/utils/report.py
@@ -346,6 +346,12 @@ class Report():
                                          "ARTIFACTS AND OTHER</b> </font>",
                                      self.styles['Bullet1']))
         self.report.append(Spacer(0 * mm, 10 * mm))
+        # aor
+        self.report.append(self.get_iqms_data('aor'))
+        self.report.append(Spacer(0 * mm, 1 * mm))
+        # aor
+        self.report.append(self.get_iqms_data('aqi'))
+        self.report.append(Spacer(0 * mm, 2.5 * mm))
         # gsr_x
         self.report.append(self.get_iqms_data('gsr_x'))
         self.report.append(Spacer(0 * mm, 1 * mm))

--- a/python/mia_processes/utils/report.py
+++ b/python/mia_processes/utils/report.py
@@ -1076,18 +1076,17 @@ class Report():
         self.report.append(slices_image)
 
 
-        # Currently, we make and save (in derived_data) the qi2 graph, but we
-        # don't include it in the report because the result with the test data
-        # looks strange.
-        # FIXME: Commented since 27/02/2027 because KeyError: 'histogram_qi2_x_grid'
-        #_ = plot_qi2(np.asarray(self.iqms_data['histogram_qi2_x_grid']),
-        #             np.asarray(self.iqms_data['histogram_qi2_ref_pdf']),
-        #             np.asarray(self.iqms_data['histogram_qi2_fit_pdf']),
-        #             np.asarray(self.iqms_data['histogram_qi2_ref_data']),
-        #             int(self.iqms_data['histogram_qi2_cutoff_idx']),
-        #             out_file=os.path.join(
-        #                 os.path.split(os.path.split(self.anat)[0])[0],
-        #                 'derived_data', 'qi2_plot.svg'))
+        # FIXME: Currently, we make and save (in derived_data) the
+        # qi2 graph, but we don't include it in the report because
+        # the result with the test data looks strange.
+        _ = plot_qi2(np.asarray(self.iqms_data['histogram_qi2_x_grid']),
+                     np.asarray(self.iqms_data['histogram_qi2_ref_pdf']),
+                     np.asarray(self.iqms_data['histogram_qi2_fit_pdf']),
+                     np.asarray(self.iqms_data['histogram_qi2_ref_data']),
+                     int(self.iqms_data['histogram_qi2_cutoff_idx']),
+                     out_file=os.path.join(
+                         os.path.split(os.path.split(self.anat)[0])[0],
+                         'derived_data', 'qi2_plot.svg'))
 
         self.page.build(self.report, canvasmaker=PageNumCanvas)
         tmpdir.cleanup()

--- a/python/mia_processes/utils/tools.py
+++ b/python/mia_processes/utils/tools.py
@@ -106,6 +106,9 @@ def dict4runtime_update(dict4runtime, database, db_filename, *args):
         if isinstance(dict4runtime[tag], datetime.date):
             dict4runtime[tag] = str(dict4runtime[tag])
 
+        if dict4runtime[tag] is None:
+            dict4runtime[tag] = "Undefined"
+
 def get_dbFieldValue(project, document, field):
     """blabla"""
 


### PR DESCRIPTION
Update some MRIQC processess :

- use white_matter mask (pve_2) in Hazmonize pipeline instead of grey matter mask (pve_1)

- add a surface extraction process  using BET and use this process for MRIQC instead of head mask pipeline 

- use "-ShowMeClassicFWHM" option to compute FWHM (as in MRIQC) 

- return -1 for fber if bg_mu < 1.0e-3

- add "aor" and "aqi" for functionnal IMQC

- remove Tshift and DropTRS from MRIQQ func pipeline 

- make optional Despike and Deoblique for MRIQQ func pipeline 



