### PR TITLE
Update report CVR and perf - convention radio / neuro

### DIFF
--- a/mia_processes/bricks/reports/reporting.py
+++ b/mia_processes/bricks/reports/reporting.py
@@ -998,6 +998,11 @@ class ReportCO2inhalCvr(ProcessMIA):
             "'Gas': 'BACTAL', 'GasAdmin': 'MASK'}"
         )
 
+        display_convention_desc = (
+            "Display convention "
+            "(a string among 'neurological' or radiological')"
+        )
+
         # Outputs description
         report_desc = "The generated report (pdf)"
 
@@ -1270,6 +1275,18 @@ class ReportCO2inhalCvr(ProcessMIA):
             MagneticFieldStrength=Undefined,
             Gas=Undefined,
             GasAdmin=Undefined,
+        )
+
+        self.add_trait(
+            "display_convention",
+            traits.Enum(
+                "radiological",
+                "neurological",
+                value="radiological",
+                output=False,
+                optional=True,
+                desc=display_convention_desc,
+            ),
         )
 
         # Outputs traits
@@ -1611,6 +1628,7 @@ class ReportCO2inhalCvr(ProcessMIA):
             spmT_vmax=self.spmT_vmax,
             mask_003=self.mask_003,
             output_directory=self.output_directory,
+            display_convention=self.display_convention,
         )
 
         report.make_report()
@@ -3290,6 +3308,10 @@ class ReportPerfDsc(ProcessMIA):
             "'Age': 64, 'Sex': 'M', MagneticFieldStrength': '3T'}"
         )
 
+        display_convention_desc = (
+            "Display convention "
+            "(a string among 'neurological' or radiological')"
+        )
         # Outputs description
         report_desc = "The generated report (pdf)"
 
@@ -3637,6 +3659,18 @@ class ReportPerfDsc(ProcessMIA):
             MagneticFieldStrength=Undefined,
         )
 
+        self.add_trait(
+            "display_convention",
+            traits.Enum(
+                "radiological",
+                "neurological",
+                value="radiological",
+                output=False,
+                optional=True,
+                desc=display_convention_desc,
+            ),
+        )
+
         # Outputs traits
         self.add_trait(
             "report",
@@ -3961,6 +3995,7 @@ class ReportPerfDsc(ProcessMIA):
             MTT_vmax=self.MTT_vmax,
             aif_file=self.aif_file,
             output_directory=self.output_directory,
+            display_convention=self.display_convention,
         )
 
         report.make_report()

--- a/mia_processes/pipelines/CerebVascularReact/co2_inhalation.py
+++ b/mia_processes/pipelines/CerebVascularReact/co2_inhalation.py
@@ -120,7 +120,8 @@ class CO2_inhalation(Pipeline):
         self.nodes["reportco2inhalcvr"].process.norm_anat_slices_gap = 5
         self.nodes["reportco2inhalcvr"].process.norm_func_inf_slice_start = 11
         self.nodes["reportco2inhalcvr"].process.norm_func_slices_gap = 2
-        self.nodes["reportco2inhalcvr"].process.beta_vmin = 0.01
+        # self.nodes["reportco2inhalcvr"].process.beta_vmin = 0.01
+        self.nodes["reportco2inhalcvr"].process.beta_vmin = -0.25
         self.nodes["reportco2inhalcvr"].process.beta_vmax = 0.25
         self.nodes["reportco2inhalcvr"].process.spmT_vmin = 3.0
         self.nodes["reportco2inhalcvr"].process.spmT_vmax = 12

--- a/mia_processes/pipelines/CerebVascularReact/co2_inhalation.py
+++ b/mia_processes/pipelines/CerebVascularReact/co2_inhalation.py
@@ -141,6 +141,9 @@ class CO2_inhalation(Pipeline):
         )
         self.add_link("func_files->make_cvr_reg_physio_1.func_file")
         self.export_parameter(
+            "reportco2inhalcvr", "display_convention", is_optional=True
+        )
+        self.export_parameter(
             "reportco2inhalcvr", "patient_info", is_optional=True
         )
         self.add_link("patient_info->4_extract_roi_param.patient_info")
@@ -241,6 +244,7 @@ class CO2_inhalation(Pipeline):
                 "conv_roi_masks",
                 "patient_info",
                 "xls_files",
+                "display_convention",
                 "report",
             )
         )

--- a/mia_processes/pipelines/Perfusion/perfdsc.py
+++ b/mia_processes/pipelines/Perfusion/perfdsc.py
@@ -164,6 +164,9 @@ class Perfdsc(Pipeline):
         )
         self.nodes["deconv_from_aif"].process.trait("T0_image").userlevel = 1
         self.export_parameter("deconv_from_aif", "T0_image", is_optional=False)
+        self.export_parameter(
+            "reportperfdsc", "display_convention", is_optional=True
+        )
         self.export_parameter("reportperfdsc", "report", is_optional=True)
         self.export_parameter(
             "reportperfdsc", "patient_info", is_optional=True
@@ -178,6 +181,7 @@ class Perfdsc(Pipeline):
                 "TTP_image",
                 "T0_image",
                 "patient_info",
+                "display_convention",
                 "report",
             )
         )

--- a/mia_processes/utils/report.py
+++ b/mia_processes/utils/report.py
@@ -565,6 +565,23 @@ class Report:
     def co2_inhal_cvr_make_report(self):
         """Make CVR under CO2 challenge report"""
 
+        if self.display_convention == "neurological":
+            convention_paragraph = Paragraph(
+                '<font size=9 > <i> "Neurological" '
+                "convention, the left side of the "
+                "image corresponds to the left side of "
+                "the brain. </i> <br/> </font>",
+                self.styles["Center"],
+            )
+        elif self.display_convention == "radiological":
+            convention_paragraph = Paragraph(
+                '<font size=9 > <i> "Radiological" '
+                "convention, the left side of the "
+                "image corresponds to the right side of "
+                "the brain. </i> <br/> </font>",
+                self.styles["Center"],
+            )
+
         # page 1 - cover ##################################################
         ###################################################################
 
@@ -869,15 +886,7 @@ class Report:
             )
         )
         self.report.append(Spacer(0 * mm, 20 * mm))
-        self.report.append(
-            Paragraph(
-                '<font size=9 > <i> "Neurological" '
-                "convention, the left side of the "
-                "image corresponds to the left side of "
-                "the brain. </i> <br/> </font>",
-                self.styles["Center"],
-            )
-        )
+        self.report.append(convention_paragraph)
         self.report.append(Spacer(0 * mm, 1 * mm))
         tmpdir = tempfile.TemporaryDirectory()
         slices_image = plot_slice_planes(
@@ -890,6 +899,7 @@ class Report:
             vmin_1=self.norm_anat_vmin,
             vmax_1=self.norm_anat_vmax,
             out_dir=tmpdir.name,
+            convention=self.display_convention,
         )
         # remainder: A4 == 210mmx297mm
         slices_image = Image(
@@ -1539,15 +1549,7 @@ class Report:
             )
         )
         self.report.append(Spacer(0 * mm, 20 * mm))
-        self.report.append(
-            Paragraph(
-                '<font size=9 > <i> "Neurological" '
-                "convention, the left side of the "
-                "image corresponds to the left side of "
-                "the brain. </i> <br/> </font>",
-                self.styles["Center"],
-            )
-        )
+        self.report.append(convention_paragraph)
         self.report.append(Spacer(0 * mm, 1 * mm))
         slices_image = plot_slice_planes(
             data_1=self.norm_func,
@@ -1559,6 +1561,7 @@ class Report:
             vmin_1=self.norm_func_vmin,
             vmax_1=self.norm_func_vmax,
             out_dir=tmpdir.name,
+            convention=self.display_convention,
         )
         # remainder: A4 == 210mmx297mm
         slices_image = Image(
@@ -1582,15 +1585,7 @@ class Report:
             )
         )
         self.report.append(Spacer(0 * mm, 20 * mm))
-        self.report.append(
-            Paragraph(
-                '<font size=9 > <i> "Neurological" '
-                "convention, the left side of the "
-                "image corresponds to the left side of "
-                "the brain. </i> <br/> </font>",
-                self.styles["Center"],
-            )
-        )
+        self.report.append(convention_paragraph)
         self.report.append(Spacer(0 * mm, 1 * mm))
         slices_image = plot_slice_planes(
             data_1=self.norm_anat,
@@ -1606,6 +1601,7 @@ class Report:
             vmin_2=self.beta_vmin,
             vmax_2=self.beta_vmax,
             out_dir=tmpdir.name,
+            convention=self.display_convention,
         )
 
         # remainder: A4 == 210mmx297mm
@@ -1626,15 +1622,7 @@ class Report:
             )
         )
         self.report.append(Spacer(0 * mm, 20 * mm))
-        self.report.append(
-            Paragraph(
-                '<font size=9 > <i> "Neurological" '
-                "convention, the left side of the "
-                "image corresponds to the left side of "
-                "the brain. </i> <br/> </font>",
-                self.styles["Center"],
-            )
-        )
+        self.report.append(convention_paragraph)
         self.report.append(Spacer(0 * mm, 1 * mm))
         slices_image = plot_slice_planes(
             data_1=self.norm_anat,
@@ -1650,6 +1638,7 @@ class Report:
             vmin_2=self.spmT_vmin,
             vmax_2=self.spmT_vmax,
             out_dir=tmpdir.name,
+            convention=self.display_convention,
         )
 
         # remainder: A4 == 210mmx297mm
@@ -1955,15 +1944,7 @@ class Report:
             )
         )
         self.report.append(Spacer(0 * mm, 15 * mm))
-        self.report.append(
-            Paragraph(
-                '<font size=9 > <i> "Neurological" '
-                "convention, the left side of the "
-                "image corresponds to the left side of "
-                "the brain. </i> <br/> </font>",
-                self.styles["Center"],
-            )
-        )
+        self.report.append(convention_paragraph)
         self.report.append(Spacer(0 * mm, 1 * mm))
         conv_roi_dir = os.path.join(
             self.output_directory,
@@ -2026,6 +2007,7 @@ class Report:
             vmax_2=None,
             out_dir=tmpdir.name,
             out_name="arterialTerritories_axial",
+            convention=self.display_convention,
         )
 
         # remainder: A4 == 210mmx297mm
@@ -2075,15 +2057,7 @@ class Report:
             )
         )
         self.report.append(Spacer(0 * mm, 15 * mm))
-        self.report.append(
-            Paragraph(
-                '<font size=9 > <i> "Neurological" '
-                "convention, the left side of the "
-                "image corresponds to the left side of "
-                "the brain. </i> <br/> </font>",
-                self.styles["Center"],
-            )
-        )
+        self.report.append(convention_paragraph)
         self.report.append(Spacer(0 * mm, 1 * mm))
         brain_lobes = [
             "convROI-CING",
@@ -2136,6 +2110,7 @@ class Report:
             vmax_2=None,
             out_dir=tmpdir.name,
             out_name="roisTerritories_axial",
+            convention=self.display_convention,
         )
         # remainder: A4 == 210mmx297mm
         slices_image = Image(
@@ -5459,6 +5434,23 @@ class Report:
     def perf_dsc_make_report(self):
         """Make DSC MR perfusion report"""
 
+        if self.display_convention == "neurological":
+            convention_paragraph = Paragraph(
+                '<font size=9 > <i> "Neurological" '
+                "convention, the left side of the "
+                "image corresponds to the left side of "
+                "the brain. </i> <br/> </font>",
+                self.styles["Center"],
+            )
+        elif self.display_convention == "radiological":
+            convention_paragraph = Paragraph(
+                '<font size=9 > <i> "Radiological" '
+                "convention, the left side of the "
+                "image corresponds to the right side of "
+                "the brain. </i> <br/> </font>",
+                self.styles["Center"],
+            )
+
         # page 1 - cover ##################################################
         ###################################################################
 
@@ -5763,15 +5755,7 @@ class Report:
             )
         )
         self.report.append(Spacer(0 * mm, 20 * mm))
-        self.report.append(
-            Paragraph(
-                '<font size=9 > <i> "Neurological" '
-                "convention, the left side of the "
-                "image corresponds to the left side of "
-                "the brain. </i> <br/> </font>",
-                self.styles["Center"],
-            )
-        )
+        self.report.append(convention_paragraph)
         self.report.append(Spacer(0 * mm, 1 * mm))
         tmpdir = tempfile.TemporaryDirectory()
         slices_image = plot_slice_planes(
@@ -5784,6 +5768,7 @@ class Report:
             vmin_1=self.norm_anat_vmin,
             vmax_1=self.norm_anat_vmax,
             out_dir=tmpdir.name,
+            convention=self.display_convention,
         )
         # remainder: A4 == 210mmx297mm
         slices_image = Image(
@@ -6404,15 +6389,7 @@ class Report:
             )
         )
         self.report.append(Spacer(0 * mm, 20 * mm))
-        self.report.append(
-            Paragraph(
-                '<font size=9 > <i> "Neurological" '
-                "convention, the left side of the "
-                "image corresponds to the left side of "
-                "the brain. </i> <br/> </font>",
-                self.styles["Center"],
-            )
-        )
+        self.report.append(convention_paragraph)
         self.report.append(Spacer(0 * mm, 1 * mm))
         slices_image = plot_slice_planes(
             data_1=self.norm_func,
@@ -6424,6 +6401,7 @@ class Report:
             vmin_1=self.norm_func_vmin,
             vmax_1=self.norm_func_vmax,
             out_dir=tmpdir.name,
+            convention=self.display_convention,
         )
         # remainder: A4 == 210mmx297mm
         slices_image = Image(
@@ -6455,15 +6433,7 @@ class Report:
             )
         )
         self.report.append(Spacer(0 * mm, 20 * mm))
-        self.report.append(
-            Paragraph(
-                '<font size=9 > <i> "Neurological" '
-                "convention, the left side of the "
-                "image corresponds to the left side of "
-                "the brain. </i> <br/> </font>",
-                self.styles["Center"],
-            )
-        )
+        self.report.append(convention_paragraph)
         self.report.append(Spacer(0 * mm, 1 * mm))
         slices_image = plot_slice_planes(
             data_1=self.norm_anat,
@@ -6479,6 +6449,7 @@ class Report:
             vmin_2=self.CBV_vmin,
             vmax_2=self.CBV_vmax,
             out_dir=tmpdir.name,
+            convention=self.display_convention,
         )
         # remainder: A4 == 210mmx297mm
         slices_image = Image(
@@ -6502,15 +6473,7 @@ class Report:
             )
         )
         self.report.append(Spacer(0 * mm, 20 * mm))
-        self.report.append(
-            Paragraph(
-                '<font size=9 > <i> "Neurological" '
-                "convention, the left side of the "
-                "image corresponds to the left side of "
-                "the brain. </i> <br/> </font>",
-                self.styles["Center"],
-            )
-        )
+        self.report.append(convention_paragraph)
         self.report.append(Spacer(0 * mm, 1 * mm))
         slices_image = plot_slice_planes(
             data_1=self.norm_anat,
@@ -6526,6 +6489,7 @@ class Report:
             vmin_2=self.CBF_vmin,
             vmax_2=self.CBF_vmax,
             out_dir=tmpdir.name,
+            convention=self.display_convention,
         )
         # remainder: A4 == 210mmx297mm
         slices_image = Image(
@@ -6545,15 +6509,7 @@ class Report:
             )
         )
         self.report.append(Spacer(0 * mm, 20 * mm))
-        self.report.append(
-            Paragraph(
-                '<font size=9 > <i> "Neurological" '
-                "convention, the left side of the "
-                "image corresponds to the left side of "
-                "the brain. </i> <br/> </font>",
-                self.styles["Center"],
-            )
-        )
+        self.report.append(convention_paragraph)
         self.report.append(Spacer(0 * mm, 1 * mm))
         slices_image = plot_slice_planes(
             data_1=self.norm_anat,
@@ -6569,6 +6525,7 @@ class Report:
             vmin_2=self.Tmax_vmin,
             vmax_2=self.Tmax_vmax,
             out_dir=tmpdir.name,
+            convention=self.display_convention,
         )
         # remainder: A4 == 210mmx297mm
         slices_image = Image(
@@ -6589,15 +6546,7 @@ class Report:
             )
         )
         self.report.append(Spacer(0 * mm, 20 * mm))
-        self.report.append(
-            Paragraph(
-                '<font size=9 > <i> "Neurological" '
-                "convention, the left side of the "
-                "image corresponds to the left side of "
-                "the brain. </i> <br/> </font>",
-                self.styles["Center"],
-            )
-        )
+        self.report.append(convention_paragraph)
         self.report.append(Spacer(0 * mm, 1 * mm))
         slices_image = plot_slice_planes(
             data_1=self.norm_anat,
@@ -6613,6 +6562,7 @@ class Report:
             vmin_2=self.MTT_vmin,
             vmax_2=self.MTT_vmax,
             out_dir=tmpdir.name,
+            convention=self.display_convention,
         )
         # remainder: A4 == 210mmx297mm
         slices_image = Image(

--- a/mia_processes/utils/tools.py
+++ b/mia_processes/utils/tools.py
@@ -690,8 +690,8 @@ def plot_slice_planes(
             else:
                 vmin = vmin_2
 
-            if vmin < 0:
-                vmin = 0.1
+            # if vmin < 0:
+            #     vmin = 0.1
 
             if vmax_2 in (None, Undefined):
                 vmax = np.max(data[~nan_indexes])

--- a/mia_processes/utils/tools.py
+++ b/mia_processes/utils/tools.py
@@ -580,6 +580,7 @@ def plot_slice_planes(
     out_dir=None,
     only_noise=False,
     out_name=None,
+    convention="neurological",
 ):
     """Create a PNG file with a mosaic display of volume slices.
 
@@ -611,10 +612,18 @@ def plot_slice_planes(
     :param out_dir: the output directory where the mosaic images will be saved.
     :param only_noise: if True, shows the noise (boolean).
     :param out_name: the suffix added to form the output name (string).
+    :param convention: display convention (neurological or radiological).
 
     Note: cmap for parametric display can be, gist_rainbow, RdYlBu, Spectral,
           rainbow_r, jet_r, seismic_r, bwr_r
     """
+
+    if convention not in ["neurological", "radiological"]:
+        print(
+            "Parameter convention should be either "
+            "radiological or neurological"
+        )
+        return
 
     if plane not in ["ax", "cor", "sag"]:
         print("Parameter plane should be either ax, sag or cor")
@@ -838,8 +847,11 @@ def plot_slice_planes(
 
         if plane == "ax":
             phys_sp = np.array(zooms[:2]) * brain_data_1[:, :, ind_slice].shape
+            data = np.swapaxes(displ_1[:, :, ind_slice], 0, 1)
+            if convention == "radiological":
+                data = np.fliplr(data)
             ax.imshow(
-                np.swapaxes(displ_1[:, :, ind_slice], 0, 1),
+                data,
                 vmin=vmin_1,
                 vmax=vmax_1,
                 cmap=cmap_1,
@@ -849,8 +861,11 @@ def plot_slice_planes(
             )
         elif plane == "sag":
             phys_sp = np.array(zooms[:2]) * brain_data_1[ind_slice, :, :].shape
+            data = np.swapaxes(displ_1[ind_slice, :, :], 0, 1)
+            if convention == "radiological":
+                data = np.fliplr(data)
             ax.imshow(
-                np.swapaxes(displ_1[ind_slice, :, :], 0, 1),
+                data,
                 vmin=vmin_1,
                 vmax=vmax_1,
                 cmap=cmap_1,
@@ -860,8 +875,11 @@ def plot_slice_planes(
             )
         elif plane == "cor":
             phys_sp = np.array(zooms[:2]) * brain_data_1[:, ind_slice, :].shape
+            data = np.swapaxes(displ_1[:, ind_slice, :], 0, 1)
+            if convention == "radiological":
+                data = np.fliplr(data)
             ax.imshow(
-                np.swapaxes(displ_1[:, ind_slice, :], 0, 1),
+                data,
                 vmin=vmin_1,
                 vmax=vmax_1,
                 cmap=cmap_1,
@@ -875,6 +893,8 @@ def plot_slice_planes(
             for i, displ in enumerate(displ_2):
                 if plane == "ax":
                     data = np.swapaxes(displ[:, :, ind_slice], 0, 1)
+                    if convention == "radiological":
+                        data = np.fliplr(data)
                     im2 = ax.imshow(
                         data,
                         vmin=vmin_2[i],
@@ -888,6 +908,8 @@ def plot_slice_planes(
                     )
                 elif plane == "sag":
                     data = np.swapaxes(displ[ind_slice, :, :], 0, 1)
+                    if convention == "radiological":
+                        data = np.fliplr(data)
                     im2 = ax.imshow(
                         data,
                         vmin=vmin_2[i],
@@ -901,6 +923,8 @@ def plot_slice_planes(
                     )
                 elif plane == "cor":
                     data = np.swapaxes(displ[:, ind_slice, :], 0, 1)
+                    if convention == "radiological":
+                        data = np.fliplr(data)
                     im2 = ax.imshow(
                         data,
                         vmin=vmin_2[i],


### PR DESCRIPTION
Following user requests, I propose the following two modifications for the CVR (CO2 inhalation pipeline) and perfusion (perfdsc report) reports:

- Added the ability to display the report according to the radiological convention (or to keep it according to the neurological convention): modification of the plot_slice_planes function and addition of a "display_convention" parameter accessible to the user in both pipelines.

- For the CVR report, centering of the color bar around 0: modification of the plot_slice_planes function and the initial value in the CO2 inhalation pipeline.

Tests performed: both pipelines were run with the display_convention parameter set to radiological, then to neurological.
